### PR TITLE
feat: add edit dialog

### DIFF
--- a/indigo-frontend/src/app/pages/project/project-add/project-add.component.html
+++ b/indigo-frontend/src/app/pages/project/project-add/project-add.component.html
@@ -1,7 +1,7 @@
 <eln-form-dialog
-  [title]="'Add Project'"
+  [title]="title"
   [fields]="fields"
   size="auto"
   containerClass="w-[800px]"
-  (formSubmit)="createProject($event)"
+  (formSubmit)="submitAction($event)"
 ></eln-form-dialog>

--- a/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
@@ -1,13 +1,14 @@
 import { FormDialogComponent } from '@/core/components/common/form-dialog/form-dialog.component';
 import { ApiService } from '@/core/services/api.service';
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
 import { catchError, of, tap } from 'rxjs';
+import { Project } from '@core/types/entities/project.i';
 
 @Component({
   standalone: true,
@@ -21,12 +22,12 @@ import { catchError, of, tap } from 'rxjs';
   ],
   templateUrl: './project-add.component.html',
 })
-export class ProjectAddComponent {
-  project!: any;
+export class ProjectAddComponent implements OnInit {
+  project!: Project;
   dialogRef = inject(MatDialogRef);
   data = inject(MAT_DIALOG_DATA);
   title = 'Add Project';
-  submitAction: (data: any) => void = this.createProject.bind(this);
+  submitAction: (data: Project) => void = this.createProject.bind(this);
   fields: FormlyFieldConfig[] = [
     {
       type: 'input',
@@ -68,6 +69,9 @@ export class ProjectAddComponent {
   ];
 
   constructor(protected service: ApiService<any>) {
+  }
+
+  ngOnInit(): void {
     this.project = this.data?.project || null;
 
     if (this.project) {
@@ -80,7 +84,7 @@ export class ProjectAddComponent {
     }
   }
 
-  createProject(data: any) {
+  createProject(data: Project) {
     this.service
       .create('projects', {
         ...data,
@@ -101,7 +105,7 @@ export class ProjectAddComponent {
       .subscribe();
   }
 
-  updateProject(data: any) {
+  updateProject(data: Project) {
     this.service
       .update(`projects/${this.project.id}`, {
         ...data,

--- a/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
@@ -3,7 +3,7 @@ import { ApiService } from '@/core/services/api.service';
 import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
@@ -22,11 +22,16 @@ import { catchError, of, tap } from 'rxjs';
   templateUrl: './project-add.component.html',
 })
 export class ProjectAddComponent {
+  project!: any;
   dialogRef = inject(MatDialogRef);
+  data = inject(MAT_DIALOG_DATA);
+  title = 'Add Project';
+  submitAction: (data: any) => void = this.createProject.bind(this);
   fields: FormlyFieldConfig[] = [
     {
       type: 'input',
       key: 'name',
+      defaultValue: '',
       props: {
         label: 'Project Name',
         placeholder: 'Project Name',
@@ -36,6 +41,7 @@ export class ProjectAddComponent {
     {
       type: 'chip-grid',
       key: 'keywords',
+      defaultValue: [],
       props: {
         label: 'Project Keywords',
         placeholder: 'Add Keyword',
@@ -44,6 +50,7 @@ export class ProjectAddComponent {
     {
       type: 'input',
       key: 'literature',
+      defaultValue: '',
       props: {
         label: 'Literature',
         placeholder: 'Literature',
@@ -52,6 +59,7 @@ export class ProjectAddComponent {
     {
       type: 'editor',
       key: 'description',
+      defaultValue: '',
       props: {
         label: 'Description',
         placeholder: 'Description',
@@ -59,7 +67,18 @@ export class ProjectAddComponent {
     },
   ];
 
-  constructor(protected service: ApiService<any>) {}
+  constructor(protected service: ApiService<any>) {
+    this.project = this.data?.project || null;
+
+    if (this.project) {
+      this.title = 'Edit Project';
+      this.submitAction = this.updateProject.bind(this);
+      this.fields = this.fields.map((field) => {
+        field.defaultValue = this.project[`${field.key}`] || '';
+        return field;
+      });
+    }
+  }
 
   createProject(data: any) {
     this.service
@@ -76,6 +95,27 @@ export class ProjectAddComponent {
         }),
         catchError((createError) => {
           alert(createError.message);
+          return of(null);
+        }),
+      )
+      .subscribe();
+  }
+
+  updateProject(data: any) {
+    this.service
+      .update(`projects/${this.project.id}`, {
+        ...data,
+        description:
+          typeof data.description === 'object'
+            ? toHTML(data.description)
+            : data.description,
+      })
+      .pipe(
+        tap(() => {
+          this.dialogRef.close('refresh');
+        }),
+        catchError((updateError) => {
+          alert(updateError.message);
           return of(null);
         }),
       )

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
@@ -13,7 +13,7 @@
     <eln-card>
       <div class="flex items-center justify-between pb-3 border-b border-b-neutral-200">
         <h2 class="font-semibold text-base">Project Description</h2>
-        <eln-button variant="blue-outline" classList="text-primary-400">
+        <eln-button variant="blue-outline" classList="text-primary-400" (click)="openEditDialog()">
           <em class="indicon-edit"></em>
           Edit
         </eln-button>

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -8,11 +8,12 @@ import { Project } from '@/core/types/entities/project.i';
 import { CommonModule } from '@angular/common';
 import { Component, inject, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subject } from 'rxjs';
+import { of, Subject, take } from 'rxjs';
 import { takeUntil, catchError } from 'rxjs/operators';
-import { of } from 'rxjs';
 import { FileUploadComponent } from "@/core/components/common/file-upload/file-upload.component";
 import { Attachment } from '@/core/types/entities/attachment.i';
+import { MatDialog } from '@angular/material/dialog';
+import { ProjectAddComponent } from '../project-add/project-add.component';
 
 @Component({
   selector: 'eln-project-info',
@@ -30,14 +31,20 @@ import { Attachment } from '@/core/types/entities/attachment.i';
 })
 export class ProjectInfoComponent implements OnInit, OnDestroy {
   activatedRoute = inject(ActivatedRoute);
-  private destroy$ = new Subject<void>();
 
-  constructor(protected service: ApiService<Project>) { }
+  dialog = inject(MatDialog);
+
+  service = inject(ApiService);
 
   project: Project | null = null;
+
   isLoading = false;
+
   hasError = false;
+
   isUploadingAttachment = false;
+
+  private destroy$ = new Subject<void>();
 
   ngOnInit() {
     this.activatedRoute.params
@@ -120,4 +127,29 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
         },
       });
   }
+
+    async openEditDialog() {
+      const ref = this.dialog.open(ProjectAddComponent, {
+        data: {
+          project: this.project,
+        },
+      });
+      ref
+        .afterClosed()
+        .pipe(
+          take(1)
+        )
+        .subscribe((result) => {
+            if (result === 'refresh') {
+              this.service
+                .request('get', `projects/${this.project.id}`)
+                .pipe(take(1))
+                .subscribe((project) => {
+                    this.project = project as typeof this.project;
+                  }
+                );
+            }
+          }
+        );
+    }
 }

--- a/indigo-frontend/src/core/services/api.service.ts
+++ b/indigo-frontend/src/core/services/api.service.ts
@@ -38,6 +38,10 @@ export class ApiService<T> {
   public create(url: string, body: unknown): Observable<T> {
     return this.httpClient.post<T>(this.buildUrl(url), body);
   }
+  
+  public update(url: string, body: unknown): Observable<T> {
+    return this.httpClient.patch<T>(this.buildUrl(url), body);
+  }
 
   public getDictionary<T = { id: string; name: string }[]>(dictionary: string): Observable<T> {
     return this.httpClient.get<T>(this.buildUrl(dictionary));


### PR DESCRIPTION
Add edit dialog to project page.
Dialog acts as just as create and uses the same component.

closes #119 

![image](https://github.com/user-attachments/assets/78db183c-9dad-4e83-81ba-1ef9b77d036c)
