### PR TITLE
feat: Upload attachments for project

### DIFF
--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
@@ -61,6 +61,7 @@
             </div>
           </div>
         }
+        <eln-file-upload (filesSelected)="onUpload($event)" [uploadingFile]="isUploadingAttachment" [withPreview]="false"/>
       </div>
     </eln-card>
 

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -11,6 +11,8 @@ import { ActivatedRoute } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil, catchError } from 'rxjs/operators';
 import { of } from 'rxjs';
+import { FileUploadComponent } from "@/core/components/common/file-upload/file-upload.component";
+import { Attachment } from '@/core/types/entities/attachment.i';
 
 @Component({
   selector: 'eln-project-info',
@@ -22,6 +24,7 @@ import { of } from 'rxjs';
     AttachmentComponent,
     // TeamComponent TODO Show team members (available in project.team response? or where?),
     CardComponent,
+    FileUploadComponent
   ],
   templateUrl: './project-info.component.html',
 })
@@ -34,6 +37,7 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
   project: Project | null = null;
   isLoading = false;
   hasError = false;
+  isUploadingAttachment = false;
 
   ngOnInit() {
     this.activatedRoute.params
@@ -55,6 +59,45 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
         attachment => attachment.id !== attachmentId
       );
     }
+  }
+
+  onUpload(files: File[]): void {
+    this.isUploadingAttachment = true;
+
+    // Validate file existence
+    const file = files[0];
+    if (!file || !this.project) {
+      console.error('No project or file selected for upload');
+      this.isUploadingAttachment = false;
+      return;
+    }
+    const formData = new FormData();
+    formData.append('file', file, file.name);
+
+    // Use the ApiService request method for file upload
+    this.service.request<Attachment[]>(
+      'post',
+      `projects/${this.project.id}/attachments`,
+      formData,
+    )
+      .pipe(
+        takeUntil(this.destroy$),
+        catchError((err) => {
+          console.error('Failed to upload attachment:', err);
+          this.isUploadingAttachment = false;
+          return of(null);
+        })
+      )
+      .subscribe({
+        next: (attachments) => {
+          if (this.project && attachments) this.project.attachments = attachments;
+        },
+        error: (err) => {
+          console.error('Upload error:', err);
+        }, complete: () => {
+          this.isUploadingAttachment = false;
+        }
+      });
   }
 
   private loadProject(id: string): void {

--- a/indigo-frontend/src/core/components/common/file-upload/file-upload.component.html
+++ b/indigo-frontend/src/core/components/common/file-upload/file-upload.component.html
@@ -1,13 +1,16 @@
-<label class="block text-gray-700 text-sm font-bold mb-2 cursor-pointer text-primary-400">
-  <div class="w-full p-4 border-2 border-dashed border-gray-300 rounded-lg text-center cursor-pointer hover:bg-gray-100">
+<label class="block text-gray-700 text-sm font-bold mb-2 cursor-pointer text-primary-400"
+  [class.opacity-50]="uploadingFile" [class.cursor-not-allowed]="uploadingFile">
+  <div class="w-full p-4 border-2 border-dashed border-gray-300 rounded-lg text-center cursor-pointer hover:bg-gray-100"
+    [class.hover:bg-gray-100]="!uploadingFile" [class.cursor-not-allowed]="uploadingFile">
     <em class="indicon-paperclip"></em>
-    Attach file
-    <input type="file" class="hidden" (change)="onFileSelect($event)" [accept]="acceptedExtensions" multiple>
+    {{ uploadingFile ? loadingText : 'Attach file' }}
+    <input type="file" class="hidden" (change)="onFileSelect($event)" [accept]="acceptedExtensions"
+      [disabled]="uploadingFile" multiple>
   </div>
 </label>
 
 <!-- Preview Selected Files -->
-@if(files.length) {
+@if(files.length && withPreview) {
 <div class="mt-4">
   @for(file of files; track file; let i = $index) {
   <div class="flex items-center justify-between p-2 bg-gray-100 rounded-lg mt-2">

--- a/indigo-frontend/src/core/components/common/file-upload/file-upload.component.ts
+++ b/indigo-frontend/src/core/components/common/file-upload/file-upload.component.ts
@@ -21,6 +21,9 @@ import { fileTypeConfig } from './file-upload.config';
 export class FileUploadComponent implements OnInit {
   @Input() maxSizeMB = 5; // Default max file size (5MB)
   @Input() allowedTypes = ['doc', 'image', 'pdf', 'xls', 'ppt', 'csv'];
+  @Input() uploadingFile = false;
+  @Input() withPreview = true;
+  @Input() loadingText = 'Uploading...';
   mimeTypes: string[] = [];
   acceptedExtensions = '';
   userService = inject(UserService);


### PR DESCRIPTION
Summary  
File Upload Implementation for Project Attachments

- Added file upload functionality to project-info component with `onUpload()` method  
- Enhanced `FileUploadComponent` with loading states (`uploadingFile`, `loadingText`) and optional preview (`withPreview`)  
- Integrated upload UI in project-info template with loading state binding  
- API integration using `FormData` POST to `/projects/{id}/attachments` endpoint returning `Attachment[]`  
- State management for upload progress with `isUploadingAttachment` flag  

**Key changes:**  
- Project attachments array updates automatically on successful upload  
- FileUpload component now supports disabled state during upload  
- Preview can be toggled off for simpler UI scenarios

**Demo**:

[Kapture 2025-07-28 at 15.16.41.webm](https://github.com/user-attachments/assets/8008b848-6b15-43e6-808d-51092f7bbef5)

