### PR TITLE
feat: Add new team member to the project

### DIFF
--- a/indigo-frontend/package-lock.json
+++ b/indigo-frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/platform-browser-dynamic": "^19.1.6",
         "@angular/router": "^19.1.6",
         "@aws-amplify/ui-angular": "^5.1.2",
+        "@ng-select/ng-select": "^14.9.0",
         "@ngx-formly/core": "^6.3.12",
         "@ngx-formly/material": "^6.3.12",
         "angular-auth-oidc-client": "19.0.0",
@@ -5737,6 +5738,24 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@ng-select/ng-select": {
+      "version": "14.9.0",
+      "resolved": "https://registry.npmjs.org/@ng-select/ng-select/-/ng-select-14.9.0.tgz",
+      "integrity": "sha512-f/E3EaSVwdKmwvZL43nS961bGaXR90F0Gtb8vA+ub8Hfwqjr1NTI6X7+yu5iMkqfy5ZW5cJdoGvo+kv8zcAkjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8"
+      },
+      "peerDependencies": {
+        "@angular/common": "^19.0.0",
+        "@angular/core": "^19.0.0",
+        "@angular/forms": "^19.0.0"
       }
     },
     "node_modules/@ngtools/webpack": {

--- a/indigo-frontend/package.json
+++ b/indigo-frontend/package.json
@@ -22,6 +22,7 @@
     "@angular/platform-browser-dynamic": "^19.1.6",
     "@angular/router": "^19.1.6",
     "@aws-amplify/ui-angular": "^5.1.2",
+    "@ng-select/ng-select": "^14.9.0",
     "@ngx-formly/core": "^6.3.12",
     "@ngx-formly/material": "^6.3.12",
     "angular-auth-oidc-client": "19.0.0",

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
@@ -64,6 +64,6 @@
         <eln-file-upload (filesSelected)="onUpload($event)" [uploadingFile]="isUploadingAttachment" [withPreview]="false"/>
       </div>
     </eln-card>
-    <eln-team [team]="project.acl" [project]="project" />
+    <eln-team [team]="project.acl" [project]="project"/>
   </div>
 }

--- a/indigo-frontend/src/core/components/project/team/team.component.html
+++ b/indigo-frontend/src/core/components/project/team/team.component.html
@@ -32,7 +32,7 @@
     <div>
       <eln-button variant="blue" (click)="addSelectedUsers()" [disabled]="selectedUserIds.length === 0 || addUserLoading">
         <em class="indicon-plus"></em>
-        Add member{{ selectedUserIds.length > 1 ? 's' : '' }}
+        {{ selectedUserIds.length | i18nPlural: addMemberLabelMap }}
       </eln-button>
     </div>
   </div>

--- a/indigo-frontend/src/core/components/project/team/team.component.html
+++ b/indigo-frontend/src/core/components/project/team/team.component.html
@@ -11,6 +11,32 @@
     </eln-button> -->
   </div>
 
+  <div class="flex items-center justify-between py-3 gap-2">
+    <div class="flex-1">
+  <ng-select [items]="userSuggestions" bindLabel="displayName" bindValue="id" [multiple]="true"
+        [closeOnSelect]="false" [searchable]="true" placeholder="Add users..." [(ngModel)]="selectedUserIds"
+        (change)="onUsersSelectedIds(selectedUserIds)" [clearable]="true" class="w-[300px]">
+        <ng-template ng-option-tmp let-item="item" let-index="index">
+          <div class="flex justify-between" [class.opacity-50]="item.added" [class.pointer-events-none]="item.added">
+            <div class="flex flex-col">
+              <span class="font-medium">{{ item.displayName }}</span>
+              <span class="text-xs text-neutral-600">{{ item.id }}</span>
+            </div>
+            <div class="flex items-center">
+              <span class="text-xs" [class.text-neutral-500]="item.added">{{ item.added ? 'Already added' : '' }}</span>
+            </div>
+          </div>
+        </ng-template>
+      </ng-select>
+    </div>
+    <div>
+      <eln-button variant="blue" (click)="addSelectedUsers()" [disabled]="selectedUserIds.length === 0 || addUserLoading">
+        <em class="indicon-plus"></em>
+        Add member{{ selectedUserIds.length > 1 ? 's' : '' }}
+      </eln-button>
+    </div>
+  </div>
+
   <div class="space-y-2 py-3">
     @for (member of team; track member) {
     <div
@@ -25,7 +51,8 @@
         <eln-copy [text]="member.username" />
         <eln-dropdown-menu class="[&_.dd-trigger]:text-primary-400 [&_.dd-container]:min-w-34" [controlled]="true"
           [selected]="member.level | normalizeLabel" [items]="aclLevelOptions"
-          (itemSelected)="updateAclLevel(member, $event)" [disabled]="isInmutableLevel(member.level) || isAclMemberLoading(member)" />
+          (itemSelected)="updateAclLevel(member, $event)"
+          [disabled]="isInmutableLevel(member.level) || isAclMemberLoading(member)" />
       </div>
     </div>
     }

--- a/indigo-frontend/src/core/components/project/team/team.component.html
+++ b/indigo-frontend/src/core/components/project/team/team.component.html
@@ -20,7 +20,7 @@
           <div class="flex justify-between" [class.opacity-50]="item.added" [class.pointer-events-none]="item.added">
             <div class="flex flex-col">
               <span class="font-medium">{{ item.displayName }}</span>
-              <span class="text-xs text-neutral-600">{{ item.id }}</span>
+              <span class="text-xs text-neutral-600">{{ item.username }}</span>
             </div>
             <div class="flex items-center">
               <span class="text-xs" [class.text-neutral-500]="item.added">{{ item.added ? 'Already added' : '' }}</span>

--- a/indigo-frontend/src/core/components/project/team/team.component.ts
+++ b/indigo-frontend/src/core/components/project/team/team.component.ts
@@ -1,18 +1,20 @@
-import { Component, inject, Input, OnDestroy } from '@angular/core';
+import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core';
 // import { AvatarComponent } from '../../common/avatar/avatar.component';
 import { CardComponent } from '../../common/card/card.component';
 import { CopyComponent } from '../../common/copy/copy.component';
 import { CounterComponent } from '../../common/counter/counter.component';
 import { DropdownMenuComponent } from '../../common/dropdown-menu/dropdown-menu.component';
-import { ProjectAcl } from '@/core/types/entities/acl.i';
-import { AclLevel } from '@/core/enums/acl-levels.enum';
+import { ProjectAcl, ProjectAclUpdate, UserSuggestion } from '@/core/types/entities/acl.i';
+import { AclLevel, ELIGIBLE_ACL_LEVELS, isInmutableLevel } from '@/core/enums/acl-levels.enum';
 import { Project } from '@/core/types/entities/project.i';
 import { ApiService } from '@/core/services/api.service';
 import { catchError, of, Subject, takeUntil } from 'rxjs';
 import { NormalizeLabelPipe } from '@/core/pipes/normalizeLabe.pipe';
-import { normalizeLabel } from '@/core/utils/string.util';
+import { ButtonComponent } from "../../common/button/button.component";
+import { NgSelectModule } from '@ng-select/ng-select';
+import { FormsModule } from '@angular/forms';
 
-const INMUTABLE_ACL_LEVELS = [AclLevel.AUTHOR]
+type UserSuggestionWithState = UserSuggestion & { added?: boolean };
 
 @Component({
   selector: 'eln-team',
@@ -25,30 +27,93 @@ const INMUTABLE_ACL_LEVELS = [AclLevel.AUTHOR]
     DropdownMenuComponent,
     CardComponent,
     NormalizeLabelPipe,
+    ButtonComponent,
+    NgSelectModule,
+    FormsModule
   ],
 })
-export class TeamComponent implements OnDestroy {
-  @Input() project: Project;
-  @Input() team: ProjectAcl[] = [];
+export class TeamComponent implements OnDestroy, OnInit {
+  aclLevelOptions = ELIGIBLE_ACL_LEVELS;
+  isInmutableLevel = isInmutableLevel;
+
+  @Input({ required: true }) project: Project;
+  @Input({ required: true }) team: ProjectAcl[] = [];
+
+  // Single suggestions list enriched with added state
+  userSuggestions: UserSuggestionWithState[] = [];
+
   private destroy$ = new Subject<void>();
   service = inject(ApiService);
-  aclMembersLoading = new Set<string>(); // Tracks which members are loading
+  addUserLoading = false;
+  aclMembersLevelLoading = new Set<string>(); // Tracks which members are loading
+  selectedUserIds: string[] = [];
 
-  isInmutableLevel(level: AclLevel): boolean {
-    return INMUTABLE_ACL_LEVELS.includes(level);
+  // Check if user is already in the team
+  private isUserInTeam(userId: string): boolean {
+    return this.team.some(m => m.userId === userId);
+  }
+
+  // Rebuild added flag on suggestions based on current team
+  // Those users already in the team should be marked as added
+  private rebuildSuggestionsState(): void {
+    this.userSuggestions.forEach(s => { s.added = this.isUserInTeam(s.id); });
   }
 
   isAclMemberLoading(member: ProjectAcl): boolean {
-    return this.aclMembersLoading.has(member.userId);
+    return this.aclMembersLevelLoading.has(member.userId);
   }
 
-  aclLevelOptions = Object.values(AclLevel)
-    .filter((value) => !this.isInmutableLevel(value))
-    .map((value) => ({
-      label: normalizeLabel(value),
-      value
-    }));
+  onUsersSelectedIds(ids: string[]): void {
+    this.selectedUserIds = ids.filter(id => !this.isUserInTeam(id));
+  }
 
+  addSelectedUsers(): void {
+    this.addUserLoading = true;
+
+    const existingPayload: ProjectAclUpdate[] = this.team.map(m => ({ userID: m.userId, level: m.level }));
+    const newPayload: ProjectAclUpdate[] = this.selectedUserIds.map(id => ({ userID: id, level: AclLevel.VIEW }));
+    const fullPayload: ProjectAclUpdate[] = [...existingPayload, ...newPayload];
+
+    this.service.request<ProjectAclUpdate[] | ProjectAclUpdate | null>(
+      'post',
+      `projects/${this.project.id}/access`,
+      fullPayload
+    )
+      .pipe(
+        takeUntil(this.destroy$),
+        catchError((err) => {
+          console.error('Failed to update project ACL with new users:', err);
+          this.addUserLoading = false;
+          return of(null);
+        })
+      )
+      .subscribe({
+        next: (resp) => {
+          if (resp === null) return;
+
+          this.selectedUserIds.forEach(id => {
+            const suggestion = this.userSuggestions.find(u => u.id === id);
+            if (!suggestion) return;
+            this.team.push({
+              userId: suggestion.id,
+              username: suggestion.username,
+              displayName: suggestion.displayName,
+              level: AclLevel.VIEW, // Assumed default level for new users
+              inherited: false // Assumed default inherited state for new users
+            });
+          });
+
+          this.rebuildSuggestionsState();
+          this.selectedUserIds = [];
+        },
+        error: (err) => {
+          console.error('Failed to update project ACL with new users:', err);
+        },
+        complete: () => {
+          this.addUserLoading = false;
+        }
+      });
+  }
   updateAclLevel(member: ProjectAcl, rawLevel: string): void {
     const newLevel = AclLevel[rawLevel as keyof typeof AclLevel];
 
@@ -58,15 +123,15 @@ export class TeamComponent implements OnDestroy {
     }
 
     // Add member to loading set
-    this.aclMembersLoading.add(member.userId);
+    this.aclMembersLevelLoading.add(member.userId);
 
-    this.service.request<Pick<ProjectAcl, 'userId' | 'level'>>('post', `projects/${this.project.id}/access`, [{ userID: member.userId, level: newLevel }])
+    this.service.request<ProjectAclUpdate>('post', `projects/${this.project.id}/access`, [{ userID: member.userId, level: newLevel }])
       .pipe(
         takeUntil(this.destroy$),
         catchError((err) => {
           console.error('Failed to update ACL level:', err);
           // Remove from loading set on error
-          this.aclMembersLoading.delete(member.userId);
+          this.aclMembersLevelLoading.delete(member.userId);
           return of(null);
         })
       )
@@ -74,14 +139,28 @@ export class TeamComponent implements OnDestroy {
         next: (projectAcl) => {
           if (projectAcl) member.level = newLevel;
           // Remove from loading set on success
-          this.aclMembersLoading.delete(member.userId);
+          this.aclMembersLevelLoading.delete(member.userId);
         },
+      });
+  }
+
+  ngOnInit(): void {
+    this.service.request<UserSuggestion[]>('get', `users/suggest`)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (userList) => {
+          this.userSuggestions = userList;
+          this.rebuildSuggestionsState();
+        },
+        error: (err) => {
+          console.error('Failed to load team members:', err);
+        }
       });
   }
 
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
-    this.aclMembersLoading.clear();
+    this.aclMembersLevelLoading.clear();
   }
 }

--- a/indigo-frontend/src/core/components/project/team/team.component.ts
+++ b/indigo-frontend/src/core/components/project/team/team.component.ts
@@ -1,4 +1,5 @@
 import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 // import { AvatarComponent } from '../../common/avatar/avatar.component';
 import { CardComponent } from '../../common/card/card.component';
 import { CopyComponent } from '../../common/copy/copy.component';
@@ -21,6 +22,7 @@ type UserSuggestionWithState = UserSuggestion & { added?: boolean };
   templateUrl: './team.component.html',
   standalone: true,
   imports: [
+    CommonModule,
     CounterComponent,
     // AvatarComponent,
     CopyComponent,
@@ -35,6 +37,12 @@ type UserSuggestionWithState = UserSuggestion & { added?: boolean };
 export class TeamComponent implements OnDestroy, OnInit {
   aclLevelOptions = ELIGIBLE_ACL_LEVELS;
   isInmutableLevel = isInmutableLevel;
+  // i18n plural map for the add members button
+  addMemberLabelMap: Record<string, string> = {
+    '=0': 'Add member',
+    '=1': 'Add member',
+    other: 'Add # members'
+  };
 
   @Input({ required: true }) project: Project;
   @Input({ required: true }) team: ProjectAcl[] = [];
@@ -56,7 +64,11 @@ export class TeamComponent implements OnDestroy, OnInit {
   // Rebuild added flag on suggestions based on current team
   // Those users already in the team should be marked as added
   private rebuildSuggestionsState(): void {
-    this.userSuggestions.forEach(s => { s.added = this.isUserInTeam(s.id); });
+    const teamIds = new Set(this.team.map(m => m.userId));
+    this.userSuggestions = this.userSuggestions.map(s => ({
+      ...s,
+      added: teamIds.has(s.id)
+    }));
   }
 
   isAclMemberLoading(member: ProjectAcl): boolean {
@@ -127,7 +139,6 @@ export class TeamComponent implements OnDestroy, OnInit {
 
     this.service.request<ProjectAclUpdate>('post', `projects/${this.project.id}/access`, [{ userID: member.userId, level: newLevel }])
       .pipe(
-        takeUntil(this.destroy$),
         catchError((err) => {
           console.error('Failed to update ACL level:', err);
           // Remove from loading set on error

--- a/indigo-frontend/src/core/enums/acl-levels.enum.ts
+++ b/indigo-frontend/src/core/enums/acl-levels.enum.ts
@@ -1,3 +1,5 @@
+import { normalizeLabel } from "../utils/string.util";
+
 export enum AclLevel {
   NONE = 'NONE',
   IMPLICIT_VIEW = 'IMPLICIT_VIEW',
@@ -6,3 +8,16 @@ export enum AclLevel {
   ADMIN = 'ADMIN',
   AUTHOR = 'AUTHOR',
 }
+
+export const INMUTABLE_ACL_LEVELS = [AclLevel.AUTHOR]
+
+export const isInmutableLevel = (level: AclLevel): boolean => {
+  return INMUTABLE_ACL_LEVELS.includes(level);
+}
+
+export const ELIGIBLE_ACL_LEVELS = Object.values(AclLevel)
+    .filter((value) => !isInmutableLevel(value))
+    .map((value) => ({
+      label: normalizeLabel(value),
+      value
+    }));

--- a/indigo-frontend/src/core/types/entities/acl.i.ts
+++ b/indigo-frontend/src/core/types/entities/acl.i.ts
@@ -7,3 +7,14 @@ export interface ProjectAcl {
   level: AclLevel;
   inherited: boolean;
 }
+
+export interface UserSuggestion {
+  id: string;
+  username: string;
+  displayName: string;
+}
+
+export interface ProjectAclUpdate {
+  userID: string;
+  level: AclLevel;
+}

--- a/indigo-frontend/src/scss/main.scss
+++ b/indigo-frontend/src/scss/main.scss
@@ -5,6 +5,8 @@
 @use 'typography';
 @use 'icons';
 
+@import '@ng-select/ng-select/themes/default.theme.css';
+
 @theme {
   --color-primary-50: var(--primary-50);
   --color-primary-100: var(--primary-100);


### PR DESCRIPTION
## Summary
Adds a multi-select (ng-select) to invite several users at once and centralizes ACL level utilities/types.

## Changes

- Added dependency `@ng-select/ng-select` + theme import (for multiple selection).
- New multi-select UI that lets adding new users to the project ACL directly (with “Already added” state).
- Centralized ACL constants/helpers (`isInmutableLevel`, eligible levels).
- Added interfaces `UserSuggestion`, `ProjectAclUpdate`.
- Added list of user suggestions loaded in the `ng-select`.

## Future Work
Remove users from ACL (UI + API).

## Demo

https://github.com/user-attachments/assets/057c26cb-f35b-4971-9399-fbb8da18e19c

