### PR TITLE
ng-257: View dictionaries

### DIFF
--- a/indigo-frontend/src/app/app.routes.ts
+++ b/indigo-frontend/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { RoleGuard } from './role.guard';
 
 export const routes: Routes = [
   {
@@ -75,6 +76,15 @@ export const routes: Routes = [
               ).then((c) => c.ExperimentsTabComponent),
           },
         ],
+      },
+      {
+        path: 'dictionary',
+        loadComponent: () =>
+          import(
+            '@/app/pages/dictionary/dictionary-layout/dictionary-layout.component'
+          ).then((c) => c.DictionaryLayoutComponent),
+        canActivate: [RoleGuard],
+        data: { requiredRole: 'Dictionary editor' },
       },
     ],
   },

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.html
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.html
@@ -1,7 +1,9 @@
 @let dataSource = dataSource$ | async;
 
 <div class="m-4">
-  <div class="flex justify-between items-center border-b border-gray-200 pb-4 mb-4">
+  <div
+    class="flex justify-between items-center border-b border-gray-200 pb-4 mb-4"
+  >
     <div class="font-semibold text-lg">Dictionary</div>
     <mat-icon
       (click)="close.emit()"
@@ -29,7 +31,9 @@
         <h3 class="font-semibold text-neutral-800 mb-2">
           Dictionary description
         </h3>
-        <p class="text-neutral-1000">{{ dictionary.description || '\u2014' }}</p>
+        <p class="text-neutral-1000">
+          {{ dictionary.description || '\u2014' }}
+        </p>
       </div>
     </div>
   </eln-card>
@@ -39,11 +43,12 @@
   <div class="flex items-center justify-center py-8">
     <span class="m-2">Loading dictionary details...</span>
   </div>
-} @else if (dataSource && dataSource.length > 0) {
+} @else if (dataSource) {
   <div class="m-4">
     <div class="max-w-1/2 my-6">
       <eln-input
         [icon]="'indicon-search text-xl'"
+        [showClearButton]="false"
         inputClassname="rounded-full bg-primary-alpha-5 border-primary-alpha-10"
         [placeholder]="'Search'"
         (input)="applyFilter($event)"
@@ -85,9 +90,7 @@
       <ng-container matColumnDef="createdAt">
         <mat-header-cell *matHeaderCellDef>Created on</mat-header-cell>
         <mat-cell *matCellDef="let element" style="white-space: nowrap">
-
-            {{ element.createdAt | date: 'dd MMM yyyy' }}
-
+          {{ element.createdAt | date: 'dd MMM yyyy' }}
         </mat-cell>
       </ng-container>
 
@@ -109,11 +112,13 @@
 
       <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
 
-      <mat-row *matNoDataRow>
-        <td colspan="6" class="text-center text-gray-500">
-          No dictionary details available.
-        </td>
-      </mat-row>
+      <ng-template matNoDataRow>
+        <tr>
+          <td class="tex-sm text-center text-gray-500 p-4">
+            No dictionary words found.
+          </td>
+        </tr>
+      </ng-template>
     </mat-table>
   </div>
 }

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.html
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.html
@@ -1,0 +1,119 @@
+@let dataSource = dataSource$ | async;
+
+<div class="m-4">
+  <div class="flex justify-between items-center border-b border-gray-200 pb-4 mb-4">
+    <div class="font-semibold text-lg">Dictionary</div>
+    <mat-icon
+      (click)="close.emit()"
+      aria-hidden="false"
+      aria-label="Close drawer"
+      fontIcon="close"
+      class="text-gray-500 hover:text-gray-700 cursor-pointer"
+    />
+  </div>
+
+  <eln-card classList="bg-gray-50 p-4">
+    <div
+      class="flex items-center justify-between pb-3 border-b border-gray-200"
+    >
+      <h3 class="text-lg font-bold text-gray-900">About dictionary</h3>
+    </div>
+
+    <div class="space-y-6 mt-3 text-sm">
+      <div>
+        <h3 class="font-semibold text-neutral-800 mb-2">Dictionary name</h3>
+        <p class="text-neutral-1000">{{ dictionary.name }}</p>
+      </div>
+
+      <div>
+        <h3 class="font-semibold text-neutral-800 mb-2">
+          Dictionary description
+        </h3>
+        <p class="text-neutral-1000">{{ dictionary.description || '\u2014' }}</p>
+      </div>
+    </div>
+  </eln-card>
+</div>
+
+@if (isLoadingDictionaryDetails) {
+  <div class="flex items-center justify-center py-8">
+    <span class="m-2">Loading dictionary details...</span>
+  </div>
+} @else if (dataSource && dataSource.length > 0) {
+  <div class="m-4">
+    <div class="max-w-1/2 my-6">
+      <eln-input
+        [icon]="'indicon-search text-xl'"
+        inputClassname="rounded-full bg-primary-alpha-5 border-primary-alpha-10"
+        [placeholder]="'Search'"
+        (input)="applyFilter($event)"
+      >
+      </eln-input>
+    </div>
+
+    <mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+      <ng-container matColumnDef="rank">
+        <mat-header-cell *matHeaderCellDef>Rank</mat-header-cell>
+        <mat-cell *matCellDef="let element">{{ element.ordinal }}</mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="name">
+        <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+        <mat-cell
+          *matCellDef="let element"
+          style="color: var(--color-primary-400)"
+          >{{ element.name }}</mat-cell
+        >
+      </ng-container>
+
+      <ng-container matColumnDef="description">
+        <mat-header-cell *matHeaderCellDef>Description</mat-header-cell>
+        <mat-cell
+          *matCellDef="let element"
+          style="color: var(--color-primary-400)"
+          >{{ element.description || '\u2014' }}</mat-cell
+        >
+      </ng-container>
+
+      <ng-container matColumnDef="active">
+        <mat-header-cell *matHeaderCellDef>Active</mat-header-cell>
+        <mat-cell *matCellDef="let element">
+          <mat-checkbox [checked]="element.active" disabled></mat-checkbox>
+        </mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="createdAt">
+        <mat-header-cell *matHeaderCellDef>Created on</mat-header-cell>
+        <mat-cell *matCellDef="let element" style="white-space: nowrap">
+
+            {{ element.createdAt | date: 'dd MMM yyyy' }}
+
+        </mat-cell>
+      </ng-container>
+
+      <ng-container matColumnDef="delete">
+        <mat-header-cell *matHeaderCellDef></mat-header-cell>
+        <mat-cell *matCellDef="let element" class="delete-cell">
+          <button
+            class="text-red-500 bg-primary-alpha-5 hover:text-red-700 cursor-pointer hover:bg-red-50 rounded p-2"
+            (click)="deleteItem(element.id)"
+            [disabled]="true"
+          >
+            <!-- remove disabled true when implement Delete dictionary item -->
+            <em class="indicon-delete"></em>
+          </button>
+        </mat-cell>
+      </ng-container>
+
+      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+
+      <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+
+      <mat-row *matNoDataRow>
+        <td colspan="6" class="text-center text-gray-500">
+          No dictionary details available.
+        </td>
+      </mat-row>
+    </mat-table>
+  </div>
+}

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.scss
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.scss
@@ -1,0 +1,34 @@
+mat-header-row {
+  font-weight: 600;
+}
+
+.mat-mdc-cell {
+  border-bottom: none !important;
+}
+
+.mat-mdc-header-cell {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.mat-elevation-z8 {
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #e0e0e0;
+  background-color: #fff;
+}
+
+.mat-column-name, .mat-column-description {
+    flex: 0 0 25%;
+}
+.mat-column-createdAt {
+    flex: 0 0 20%;
+}
+.mat-column-rank, .mat-column-active, .mat-column-delete {
+    flex: 0 0 10%;
+}
+
+.delete-cell {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 6px;
+}

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.ts
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.ts
@@ -1,0 +1,124 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnChanges,
+} from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import {
+  DictionaryFull,
+  DictionaryListItem,
+} from '@/core/types/entities/dictionary.i';
+import { DictionaryService } from '@/core/services/dictionary/dictionary.service';
+import { MatIcon } from '@angular/material/icon';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatSortModule } from '@angular/material/sort';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { CardComponent } from '@/core/components/common/card/card.component';
+import { InputComponent } from '@/core/components/common/input/input.component';
+
+@Component({
+  selector: 'eln-dictionary-drawer',
+  templateUrl: './dictionary-drawer.component.html',
+  imports: [
+    MatIcon,
+    CommonModule,
+    MatTableModule,
+    MatCheckboxModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    CardComponent,
+    InputComponent,
+    MatProgressSpinnerModule,
+  ],
+  styleUrls: ['./dictionary-drawer.component.scss'],
+  standalone: true,
+})
+export class DictionaryDrawerComponent implements OnChanges {
+  @Input() dictionary: DictionaryListItem | null = null;
+  @Output() close = new EventEmitter<void>();
+
+  dataSource$ = new BehaviorSubject<DictionaryFull>([]);
+
+  displayedColumns: string[] = [
+    'rank',
+    'name',
+    'description',
+    'active',
+    'createdAt',
+    'delete',
+  ];
+  private lastId: string | null = null;
+  isLoadingDictionaryDetails = false;
+
+  /* Cache the original data to support filtering */
+  private originalData: DictionaryFull = [];
+
+  constructor(private dictionaryService: DictionaryService) {}
+
+  ngOnChanges(): void {
+    if (this.dictionary) {
+      if (this.dictionary.id !== this.lastId) {
+        this.lastId = this.dictionary.id;
+        this.getDictionaryDetails();
+      }
+    } else {
+      this.lastId = null;
+      this.originalData = [];
+      this.dataSource$.next([]);
+      this.isLoadingDictionaryDetails = false;
+    }
+  }
+
+  private getDictionaryDetails(): void {
+    this.isLoadingDictionaryDetails = true;
+    this.dictionaryService.getDictionaryDetails(this.dictionary!.id).subscribe({
+      next: (response) => {
+        this.originalData = response;
+        this.dataSource$.next(response);
+        this.isLoadingDictionaryDetails = false;
+      },
+      error: (err) => {
+        console.error('Error fetching dictionary details:', err);
+        this.isLoadingDictionaryDetails = false;
+      },
+    });
+  }
+
+  applyFilter(event: Event): void {
+    const filterValue = (event.target as HTMLInputElement).value.toLowerCase();
+
+    if (!filterValue) {
+      this.dataSource$.next([...this.originalData]);
+      return;
+    }
+
+    const filteredData = this.originalData.filter((item) =>
+      item.name.toLowerCase().includes(filterValue),
+    );
+
+    this.dataSource$.next(filteredData);
+  }
+
+  deleteItem(itemId: string): void {
+    if (!this.dictionary?.id) {
+      return;
+    }
+
+    this.dictionaryService
+      .deleteDictionaryItem(this.dictionary.id, itemId)
+      .subscribe({
+        next: (updatedDictionary) => {
+          this.originalData = updatedDictionary;
+          this.dataSource$.next(updatedDictionary);
+        },
+        error: (err) => console.error('Error deleting item:', err),
+      });
+  }
+}

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.ts
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.ts
@@ -4,6 +4,7 @@ import {
   Output,
   EventEmitter,
   OnChanges,
+  inject,
 } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import {
@@ -44,6 +45,8 @@ export class DictionaryDrawerComponent implements OnChanges {
   @Input() dictionary: DictionaryListItem | null = null;
   @Output() close = new EventEmitter<void>();
 
+  private dictionaryService = inject(DictionaryService);
+
   dataSource$ = new BehaviorSubject<DictionaryFull>([]);
 
   displayedColumns: string[] = [
@@ -59,8 +62,6 @@ export class DictionaryDrawerComponent implements OnChanges {
 
   /* Cache the original data to support filtering */
   private originalData: DictionaryFull = [];
-
-  constructor(private dictionaryService: DictionaryService) {}
 
   ngOnChanges(): void {
     if (this.dictionary) {

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-layout/dictionary-layout.component.html
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-layout/dictionary-layout.component.html
@@ -1,0 +1,26 @@
+<mat-drawer-container hasBackdrop="false">
+  <mat-drawer
+    mode="over"
+    position="end"
+    [style.width.%]="60"
+    [style.min-width.px]="400"
+    [style.boxShadow]="'0 8px 16px rgba(0, 0, 0, 0.2)'"
+    [style.background]="'white'"
+    [opened]="isDrawerOpen"
+    (closed)="closeDrawer()"
+  >
+    @if (selectedDictionary) {
+      <eln-dictionary-drawer
+        [dictionary]="selectedDictionary"
+        (close)="closeDrawer()"
+      />
+    }
+  </mat-drawer>
+
+  <mat-drawer-content>
+    <div class="font-semibold text-lg">Dictionary</div>
+    <eln-dictionary-list
+      (selectDictionaryEvent)="onDictionarySelected($event)"
+    />
+  </mat-drawer-content>
+</mat-drawer-container>

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-layout/dictionary-layout.component.ts
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-layout/dictionary-layout.component.ts
@@ -1,0 +1,38 @@
+import { DictionaryListItem } from '@/core/types/entities/dictionary.i';
+import { Component } from '@angular/core';
+import {
+  MatDrawerContent,
+  MatDrawerContainer,
+  MatDrawer,
+} from '@angular/material/sidenav';
+import { DictionaryListComponent } from '../dictionary-list/dictionary-list.component';
+import { DictionaryDrawerComponent } from '../dictionary-drawer/dictionary-drawer.component';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'eln-dictionary-layout',
+  templateUrl: './dictionary-layout.component.html',
+  imports: [
+    MatDrawerContent,
+    MatDrawerContainer,
+    MatDrawer,
+    DictionaryListComponent,
+    DictionaryDrawerComponent,
+    CommonModule,
+  ],
+  standalone: true,
+})
+export class DictionaryLayoutComponent {
+  isDrawerOpen = false;
+  selectedDictionary: DictionaryListItem | null = null;
+
+  onDictionarySelected(dictionary: DictionaryListItem): void {
+    this.selectedDictionary = { ...dictionary };
+    this.isDrawerOpen = true;
+  }
+
+  closeDrawer(): void {
+    this.isDrawerOpen = false;
+    this.selectedDictionary = null;
+  }
+}

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-list/dictionary-list.component.html
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-list/dictionary-list.component.html
@@ -1,0 +1,60 @@
+@if (isLoading) {
+ <div class="flex items-center justify-center h-screen">
+  Loading dictionaries...
+</div>
+}
+
+@if (hasError) {
+  <div class="text-center p-4">
+    <p>Error loading dictionaries.</p>
+  </div>
+}
+
+@if (!isLoading && !hasError && dictionaries.length > 0) {
+  <div class="flex flex-col gap-4 py-4">
+    @for (dictionary of dictionaries; track dictionary.id) {
+      <div
+        class="hover:cursor-pointer rounded-2xl overflow-hidden shadow hover:shadow-lg transition-shadow"
+      >
+        <eln-card (click)="selectDictionary(dictionary)" classList="p-4">
+          <div class="flex gap-2 items-center">
+            <em class="indicon-book" [style.color]="'var(--color-primary-400)'"></em>
+            <h2 class="font-semibold text-base">{{ dictionary.name }}</h2>
+          </div>
+
+          <div class="flex justify-between gap-8 pt-4 text-sm">
+
+            <div class="flex-1">
+              <h3 class="text-neutral-800 mb-2">Description</h3>
+              <p class="text-neutral-1000">{{ dictionary.description }}</p>
+            </div>
+
+            <div class="flex-1">
+              <h3 class="text-neutral-800 mb-2 whitespace-nowrap">
+                Last Edited on
+              </h3>
+              <p class="text-neutral-1000 whitespace-nowrap">
+                {{ dictionary.modifiedAt | date: 'dd MMMM yyyy' }}
+              </p>
+            </div>
+
+
+            <div class="flex-1">
+              <h3 class="text-neutral-800 mb-2 whitespace-nowrap">
+                Last Edited by
+              </h3>
+              <p class="text-neutral-1000">
+                {{ dictionary.modifiedBy.displayName }}
+              </p>
+            </div>
+
+          </div>
+        </eln-card>
+      </div>
+    }
+  </div>
+} @else if (!isLoading) {
+  <div class="text-center p-4">
+    <p>No dictionaries available.</p>
+  </div>
+}

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-list/dictionary-list.component.html
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-list/dictionary-list.component.html
@@ -1,11 +1,11 @@
 @if (isLoading) {
- <div class="flex items-center justify-center h-screen">
-  Loading dictionaries...
-</div>
+  <div class="flex items-center justify-center h-screen">
+    Loading dictionaries...
+  </div>
 }
 
 @if (hasError) {
-  <div class="text-center p-4">
+  <div class="flex items-center justify-center h-screen">
     <p>Error loading dictionaries.</p>
   </div>
 }
@@ -18,12 +18,11 @@
       >
         <eln-card (click)="selectDictionary(dictionary)" classList="p-4">
           <div class="flex gap-2 items-center">
-            <em class="indicon-book" [style.color]="'var(--color-primary-400)'"></em>
+            <mat-icon class="material-icons-outlined" [style.color]="'var(--color-primary-400)'">import_contacts</mat-icon>
             <h2 class="font-semibold text-base">{{ dictionary.name }}</h2>
           </div>
 
           <div class="flex justify-between gap-8 pt-4 text-sm">
-
             <div class="flex-1">
               <h3 class="text-neutral-800 mb-2">Description</h3>
               <p class="text-neutral-1000">{{ dictionary.description }}</p>
@@ -38,7 +37,6 @@
               </p>
             </div>
 
-
             <div class="flex-1">
               <h3 class="text-neutral-800 mb-2 whitespace-nowrap">
                 Last Edited by
@@ -47,13 +45,12 @@
                 {{ dictionary.modifiedBy.displayName }}
               </p>
             </div>
-
           </div>
         </eln-card>
       </div>
     }
   </div>
-} @else if (!isLoading) {
+} @else if (!isLoading && !hasError) {
   <div class="text-center p-4">
     <p>No dictionaries available.</p>
   </div>

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-list/dictionary-list.component.ts
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-list/dictionary-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, inject } from '@angular/core';
 import {
   DictionaryList,
   DictionaryListItem,
@@ -15,14 +15,13 @@ import { MatIconModule } from '@angular/material/icon';
   standalone: true,
 })
 export class DictionaryListComponent implements OnInit {
+  private dictionaryService = inject(DictionaryService);
   dictionaries: DictionaryList = [];
   selectedDictionary: DictionaryListItem | null = null;
   isLoading = true;
   hasError = false;
 
   @Output() selectDictionaryEvent = new EventEmitter<DictionaryListItem>();
-
-  constructor(private dictionaryService: DictionaryService) {}
 
   ngOnInit(): void {
     this.fetchDictionaries();

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-list/dictionary-list.component.ts
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-list/dictionary-list.component.ts
@@ -6,11 +6,12 @@ import {
 import { DictionaryService } from '@/core/services/dictionary/dictionary.service';
 import { CardComponent } from '@/core/components/common/card/card.component';
 import { DatePipe } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'eln-dictionary-list',
   templateUrl: './dictionary-list.component.html',
-  imports: [CardComponent, DatePipe],
+  imports: [CardComponent, DatePipe, MatIconModule],
   standalone: true,
 })
 export class DictionaryListComponent implements OnInit {

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-list/dictionary-list.component.ts
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-list/dictionary-list.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import {
+  DictionaryList,
+  DictionaryListItem,
+} from '@/core/types/entities/dictionary.i';
+import { DictionaryService } from '@/core/services/dictionary/dictionary.service';
+import { CardComponent } from '@/core/components/common/card/card.component';
+import { DatePipe } from '@angular/common';
+
+@Component({
+  selector: 'eln-dictionary-list',
+  templateUrl: './dictionary-list.component.html',
+  imports: [CardComponent, DatePipe],
+  standalone: true,
+})
+export class DictionaryListComponent implements OnInit {
+  dictionaries: DictionaryList = [];
+  selectedDictionary: DictionaryListItem | null = null;
+  isLoading = true;
+  hasError = false;
+
+  @Output() selectDictionaryEvent = new EventEmitter<DictionaryListItem>();
+
+  constructor(private dictionaryService: DictionaryService) {}
+
+  ngOnInit(): void {
+    this.fetchDictionaries();
+  }
+
+  fetchDictionaries(): void {
+    this.isLoading = true;
+    this.hasError = false;
+
+    this.dictionaryService.getDictionaries().subscribe({
+      next: (dictionaries) => {
+        this.dictionaries = dictionaries;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.hasError = true;
+        this.isLoading = false;
+      },
+    });
+  }
+
+  selectDictionary(dictionary: DictionaryListItem): void {
+    this.selectedDictionary = dictionary;
+    this.selectDictionaryEvent.emit(dictionary);
+  }
+}

--- a/indigo-frontend/src/app/role.guard.ts
+++ b/indigo-frontend/src/app/role.guard.ts
@@ -1,7 +1,7 @@
 import { UserService } from '@/core/services/user.service';
 import { Role } from '@/core/types/entities/user.i';
 import { Injectable } from '@angular/core';
-import { CanActivate, Router } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -11,7 +11,7 @@ import { map } from 'rxjs/operators';
 export class RoleGuard implements CanActivate {
   constructor(private userService: UserService, private router: Router) {}
 
-  canActivate(route: import('@angular/router').ActivatedRouteSnapshot): Observable<boolean> {
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
     const requiredRole = route.data['requiredRole'];
     return this.userService.userRoles$.pipe(
       map((roles: Role[]) => {

--- a/indigo-frontend/src/app/role.guard.ts
+++ b/indigo-frontend/src/app/role.guard.ts
@@ -1,0 +1,26 @@
+import { UserService } from '@/core/services/user.service';
+import { Role } from '@/core/types/entities/user.i';
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RoleGuard implements CanActivate {
+  constructor(private userService: UserService, private router: Router) {}
+
+  canActivate(route: import('@angular/router').ActivatedRouteSnapshot): Observable<boolean> {
+    const requiredRole = route.data['requiredRole'];
+    return this.userService.userRoles$.pipe(
+      map((roles: Role[]) => {
+        const hasRole = roles.some((role) => role.name === requiredRole);
+        if (!hasRole) {
+          this.router.navigate(['/']);
+        }
+        return hasRole;
+      })
+    );
+  }
+}

--- a/indigo-frontend/src/core/components/common/input/input.component.html
+++ b/indigo-frontend/src/core/components/common/input/input.component.html
@@ -44,7 +44,7 @@
       [disabled]="disabled()"
     />
 
-    @if (value() && !disabled()) {
+    @if (value() && !disabled() && showClearButton) {
       <em
         class="chip-icon indicon-close text-lg cursor-pointer absolute z-50 right-2"
         (click)="clearValue()"

--- a/indigo-frontend/src/core/components/common/input/input.component.ts
+++ b/indigo-frontend/src/core/components/common/input/input.component.ts
@@ -31,6 +31,7 @@ export class InputComponent implements ControlValueAccessor {
   @Input() inputWrapperClassname: string;
   @Input() inputClassname: string;
   @Input() iconClassname: string;
+  @Input() showClearButton = true;
   label = input<string>();
   placeholder = input<string>();
   required = input<boolean>(false);

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.html
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.html
@@ -18,14 +18,29 @@
     </li>
     <li
       *ngFor="let item of menu$ | async"
-      routerLinkActive="active"
+      [ngClass]="{ active: isMenuItemActive(item.path) }"
       class="my-3 [&.active]:bg-primary-alpha-10 [&.active_a_em]:text-primary-400 rounded-lg"
     >
       <a
         [routerLink]="item.path"
         class="flex items-center gap-2 rounded-lg p-3 text-neutral-1000 hover:bg-primary-alpha-10 hover:text-primary-400"
       >
-        <em [class]="item.icon" class="text-xl flex-shrink-0"></em>
+        <em
+          *ngIf="item.icon"
+          [class]="item.icon"
+          class="text-xl flex-shrink-0"
+        ></em>
+        <mat-icon
+          *ngIf="item.materialIcon"
+          class="text-xl flex-shrink-0"
+          [ngStyle]="{
+            color: isMenuItemActive(item.path)
+              ? 'var(--color-primary-400)'
+              : 'var(--neutral-color-600)',
+          }"
+        >
+          {{ item.materialIcon }}
+        </mat-icon>
         <span
           class="font-semibold text-h4 whitespace-nowrap"
           *ngIf="isSidebarOpen"
@@ -34,5 +49,8 @@
       </a>
     </li>
   </ul>
-  <eln-starred-experiments *ngIf="isSidebarOpen" class="block mt-2"></eln-starred-experiments>
+  <eln-starred-experiments
+    *ngIf="isSidebarOpen"
+    class="block mt-2"
+  ></eln-starred-experiments>
 </nav>

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.html
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.html
@@ -17,7 +17,7 @@
       </a>
     </li>
     <li
-      *ngFor="let item of menu"
+      *ngFor="let item of menu$ | async"
       routerLinkActive="active"
       class="my-3 [&.active]:bg-primary-alpha-10 [&.active_a_em]:text-primary-400 rounded-lg"
     >

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.spec.ts
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.spec.ts
@@ -23,7 +23,9 @@ describe('SidebarComponent', () => {
   it('should initialize with default values', () => {
     expect(component.isSidebarOpen).toBe(true);
     expect(component.isHovered).toBe(false);
-    expect(component.menu.length).toBe(2);
+    component.menu$.subscribe(menu => {
+      expect(menu.length).toBe(2);
+    });
   });
 
   it('should have correct menu items', () => {
@@ -39,7 +41,9 @@ describe('SidebarComponent', () => {
         path: '/dashboard',
       },
     ];
-    expect(component.menu).toEqual(expectedMenu);
+    component.menu$.subscribe(menu => {
+      expect(menu).toEqual(expectedMenu);
+    });
   });
 
   describe('toggleSidebar', () => {
@@ -59,10 +63,13 @@ describe('SidebarComponent', () => {
   });
 
   describe('template rendering', () => {
-    it('should render correct number of menu items', () => {
+    it('should render correct number of menu items', (done) => {
       const menuItems = fixture.nativeElement.querySelectorAll('li');
       // Add 1 to account for the toggle button li
-      expect(menuItems.length).toBe(component.menu.length + 1);
+      component.menu$.subscribe(menu => {
+        expect(menuItems.length).toBe(menu.length + 1);
+        done();
+      });
     });
 
     it('should toggle sidebar collapsed class', () => {

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
@@ -1,11 +1,19 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { StarredExperimentsComponent } from './starred-experiments/starred-experiments.component';
 import { map, Observable } from 'rxjs';
 import { UserService } from '@/core/services/user.service';
 import { Role } from '@/core/types/entities/user.i';
 import { MatIconModule } from '@angular/material/icon';
+
+interface MenuItem {
+  name: string;
+  path: string;
+  requiredRole?: string;
+  icon?: string;
+  materialIcon?: string;
+}
 
 @Component({
   standalone: true,
@@ -19,6 +27,9 @@ import { MatIconModule } from '@angular/material/icon';
   templateUrl: './sidebar.component.html',
 })
 export class SidebarComponent {
+  private userService = inject(UserService);
+  private router = inject(Router);
+
   private fullMenu = [
     {
       name: 'Projects',
@@ -38,33 +49,18 @@ export class SidebarComponent {
     },
   ];
 
-  menu$: Observable<
-    {
-      name: string;
-      path: string;
-      requiredRole?: string;
-      icon?: string;
-      materialIcon?: string;
-    }[]
-  >;
+  menu$: Observable<MenuItem[]> = this.userService.userRoles$.pipe(
+    map((roles: Role[]) => {
+      const roleNames = roles.map((role) => role.name);
+      return this.fullMenu.filter(
+        (menuItem) =>
+          !menuItem.requiredRole || roleNames.includes(menuItem.requiredRole),
+      );
+    }),
+  );
 
   isSidebarOpen = true;
   isHovered = false;
-
-  constructor(
-    private userService: UserService,
-    private router: Router,
-  ) {
-    this.menu$ = this.userService.userRoles$.pipe(
-      map((roles: Role[]) => {
-        const roleNames = roles.map((role) => role.name);
-        return this.fullMenu.filter(
-          (menuItem) =>
-            !menuItem.requiredRole || roleNames.includes(menuItem.requiredRole),
-        );
-      }),
-    );
-  }
 
   toggleSidebar() {
     this.isSidebarOpen = !this.isSidebarOpen;

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
@@ -2,6 +2,9 @@ import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { StarredExperimentsComponent } from './starred-experiments/starred-experiments.component';
+import { map, Observable } from 'rxjs';
+import { UserService } from '@/core/services/user.service';
+import { Role } from '@/core/types/entities/user.i';
 
 @Component({
   standalone: true,
@@ -10,7 +13,7 @@ import { StarredExperimentsComponent } from './starred-experiments/starred-exper
   templateUrl: './sidebar.component.html',
 })
 export class SidebarComponent {
-  menu = [
+  private fullMenu = [
     {
       name: 'Projects',
       icon: 'indicon-briefcase',
@@ -23,12 +26,30 @@ export class SidebarComponent {
     },
     {
       name: 'Dictionary',
-      icon: 'indicon-terminal',
+      icon: 'indicon-book',
       path: '/dictionary',
+      requiredRole: 'Dictionary editor',
     },
   ];
+
+  menu$: Observable<
+    { name: string; icon: string; path: string; requiredRole?: string }[]
+  >;
+
   isSidebarOpen = true;
   isHovered = false;
+
+  constructor(private userService: UserService) {
+    this.menu$ = this.userService.userRoles$.pipe(
+      map((roles: Role[]) => {
+        const roleNames = roles.map((role) => role.name);
+        return this.fullMenu.filter(
+          (menuItem) =>
+            !menuItem.requiredRole || roleNames.includes(menuItem.requiredRole)
+        );
+      })
+    );
+  }
 
   toggleSidebar() {
     this.isSidebarOpen = !this.isSidebarOpen;

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
@@ -1,14 +1,20 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { StarredExperimentsComponent } from './starred-experiments/starred-experiments.component';
 import { map, Observable } from 'rxjs';
 import { UserService } from '@/core/services/user.service';
 import { Role } from '@/core/types/entities/user.i';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, RouterModule, StarredExperimentsComponent],
+  imports: [
+    CommonModule,
+    RouterModule,
+    StarredExperimentsComponent,
+    MatIconModule,
+  ],
   selector: 'eln-sidebar',
   templateUrl: './sidebar.component.html',
 })
@@ -26,33 +32,53 @@ export class SidebarComponent {
     },
     {
       name: 'Dictionary',
-      icon: 'indicon-book',
+      materialIcon: 'import_contacts',
       path: '/dictionary',
       requiredRole: 'Dictionary editor',
     },
   ];
 
   menu$: Observable<
-    { name: string; icon: string; path: string; requiredRole?: string }[]
+    {
+      name: string;
+      path: string;
+      requiredRole?: string;
+      icon?: string;
+      materialIcon?: string;
+    }[]
   >;
 
   isSidebarOpen = true;
   isHovered = false;
 
-  constructor(private userService: UserService) {
+  constructor(
+    private userService: UserService,
+    private router: Router,
+  ) {
     this.menu$ = this.userService.userRoles$.pipe(
       map((roles: Role[]) => {
         const roleNames = roles.map((role) => role.name);
         return this.fullMenu.filter(
           (menuItem) =>
-            !menuItem.requiredRole || roleNames.includes(menuItem.requiredRole)
+            !menuItem.requiredRole || roleNames.includes(menuItem.requiredRole),
         );
-      })
+      }),
     );
   }
 
   toggleSidebar() {
     this.isSidebarOpen = !this.isSidebarOpen;
     this.isHovered = false;
+  }
+
+  isMenuItemActive(path: string) {
+    const currentPath = this.router.url.split('?')[0];
+    const isProjectPathActive = true;
+
+    if (path === '/' && currentPath === '/projects') {
+      return isProjectPathActive;
+    }
+
+    return currentPath === path;
   }
 }

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
@@ -42,7 +42,7 @@ export class SidebarComponent {
       path: '/templates',
     },
     {
-      name: 'Dictionary',
+      name: 'Dictionaries',
       materialIcon: 'import_contacts',
       path: '/dictionary',
       requiredRole: 'Dictionary editor',

--- a/indigo-frontend/src/core/services/dictionary/dictionary.service.ts
+++ b/indigo-frontend/src/core/services/dictionary/dictionary.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { ApiService } from '@/core/services/api.service';
+import { Observable } from 'rxjs';
+import {
+  DictionaryFull,
+  DictionaryList,
+} from '@/core/types/entities/dictionary.i';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DictionaryService {
+  constructor(private api: ApiService<unknown>) {}
+
+  getDictionaries(): Observable<DictionaryList> {
+    return this.api.request<DictionaryList>('get', 'dictionaries');
+  }
+
+  getDictionaryDetails(id: string): Observable<DictionaryFull> {
+    return this.api.request<DictionaryFull>('get', `dictionaries/${id}/full`);
+  }
+
+  deleteDictionaryItem(
+    dictionaryId: string,
+    itemId: string,
+  ): Observable<DictionaryFull> {
+    return this.api.request<DictionaryFull>(
+      'delete',
+      `dictionaries/${dictionaryId}/${itemId}`,
+    );
+  }
+}

--- a/indigo-frontend/src/core/services/user.service.ts
+++ b/indigo-frontend/src/core/services/user.service.ts
@@ -1,15 +1,43 @@
 import { Injectable } from '@angular/core';
 import { fetchAuthSession } from 'aws-amplify/auth';
-import { from, map, Observable } from 'rxjs';
+import { from, map, Observable, switchMap } from 'rxjs';
 import { ElnJwtPayload } from '../types/jwt-payload.i';
+import { ApiService } from './api.service';
+import { HttpParams } from '@angular/common/http';
+import { Role, UsersResponse } from '../types/entities/user.i';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UserService {
+  constructor(private api: ApiService<unknown>) { }
+  
   public user$: Observable<ElnJwtPayload> = from(fetchAuthSession()).pipe(
     map(
       (session) => session.tokens.idToken.payload as unknown as ElnJwtPayload,
     ),
   );
+
+public userRoles$: Observable<Role[]> = this.user$.pipe(
+  map((jwtPayload) => jwtPayload['cognito:username']),
+  switchMap((username) =>
+    this.getUsers(username).pipe(
+      map((usersResponse: UsersResponse) => {
+        const user = usersResponse.items?.find((item) => item.username === username);
+        return user?.roles || [];
+      })
+    )
+  )
+);
+
+  getUsers(username?: string): Observable<UsersResponse> {
+    let params = new HttpParams();
+    if (username) {
+      params = params.set('username', username);
+    }
+
+    const options = { params };
+
+    return this.api.request<UsersResponse>('get', 'users', null, options);
+  }
 }

--- a/indigo-frontend/src/core/types/entities/dictionary.i.ts
+++ b/indigo-frontend/src/core/types/entities/dictionary.i.ts
@@ -1,0 +1,20 @@
+import { BaseEntity } from './base-entity.i';
+
+export interface DictionaryListItem extends BaseEntity {
+  name: string;
+  description: string;
+  code: string;
+}
+
+export type DictionaryList = DictionaryListItem[];
+
+export interface DictionaryFullItem {
+    id: string;
+    createdAt: Date;
+    name: string;
+    description: string;
+    ordinal: number;
+    active: boolean;
+}
+
+export type DictionaryFull = DictionaryFullItem[];

--- a/indigo-frontend/src/core/types/entities/user.i.ts
+++ b/indigo-frontend/src/core/types/entities/user.i.ts
@@ -1,0 +1,31 @@
+export interface UsersResponse {
+  pageNo: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+  items: User[];
+}
+
+export interface User {
+  id: string;
+  createdBy: UserMetadata;
+  createdAt: string;
+  modifiedBy: UserMetadata;
+  modifiedAt: string;
+  username: string;
+  firstName: string | null;
+  lastName: string | null;
+  displayName: string;
+  roles: Role[];
+}
+
+export interface UserMetadata {
+  id: string;
+  username: string;
+  displayName: string;
+}
+
+export interface Role {
+  id: string;
+  name: string;
+}

--- a/indigo-frontend/src/index.html
+++ b/indigo-frontend/src/index.html
@@ -13,7 +13,7 @@
       rel="stylesheet"
     />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
     />
   </head>


### PR DESCRIPTION
closes View Dictionaries AC in [FE task 267](https://github.com/epam/Indigo-ELN-v.-2.0/issues/267)

**1) Adds view Dictionaries List:**
<img width="1920" height="971" alt="Screenshot (1419)" src="https://github.com/user-attachments/assets/2c848dc2-e29f-4682-96f7-8db6e9ddd136" />


**2) Dictionary details drawer:**
<img width="1920" height="970" alt="Screenshot (1420)" src="https://github.com/user-attachments/assets/bbb5d670-8c39-4cb7-95e2-8bbe3b63f1c2" />

**Case insensistive search in table:**

<img width="1920" height="957" alt="Screenshot (1421)" src="https://github.com/user-attachments/assets/f3a9da2c-6c23-4543-8166-69172e4e13da" />


**3) Role guard for dictionary route and sidebar dictionary option:**

<img width="1920" height="980" alt="Screenshot (1410)" src="https://github.com/user-attachments/assets/d99a635c-1444-4301-865c-f710e1384f75" />

**4) non active state for dictionary sidebar item:**
<img width="1920" height="944" alt="Screenshot (1414)" src="https://github.com/user-attachments/assets/7f4d0f0e-752f-4c4e-bfd5-292fcceb6d33" />

