### PR TITLE
ng-274: add and delete word from dictionary

### DIFF
--- a/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.html
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.html
@@ -45,15 +45,28 @@
   </div>
 } @else if (dataSource) {
   <div class="m-4">
-    <div class="max-w-1/2 my-6">
-      <eln-input
-        [icon]="'indicon-search text-xl'"
-        [showClearButton]="false"
-        inputClassname="rounded-full bg-primary-alpha-5 border-primary-alpha-10"
-        [placeholder]="'Search'"
-        (input)="applyFilter($event)"
+    <div
+      class="flex justify-between items-center border-b border-gray-200 pb-4 mb-4"
+    >
+      <div class="max-w-1/2 my-6">
+        <eln-input
+          [icon]="'indicon-search text-xl'"
+          [showClearButton]="false"
+          inputClassname="rounded-full bg-primary-alpha-5 border-primary-alpha-10"
+          [placeholder]="'Search'"
+          (input)="applyFilter($event)"
+        >
+        </eln-input>
+      </div>
+
+      <eln-button
+        variant="grey"
+        classList="flex items-center gap-2"
+        (click)="addNewWordRowToTable()"
       >
-      </eln-input>
+        <em class="text-xl indicon-plus"></em>
+        <span class="whitespace-nowrap">Add word</span>
+      </eln-button>
     </div>
 
     <mat-table [dataSource]="dataSource" class="mat-elevation-z8">
@@ -64,11 +77,27 @@
 
       <ng-container matColumnDef="name">
         <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
-        <mat-cell
-          *matCellDef="let element"
-          style="color: var(--color-primary-400)"
-          >{{ element.name }}</mat-cell
-        >
+        <mat-cell *matCellDef="let word; let i = index">
+          @if (word.id) {
+            <span>{{ word.name }}</span>
+          } @else {
+            <mat-form-field class="w-full">
+              <input
+                matInput
+                required
+                [formControl]="getFormControl(formRows[i], 'name')"
+                (blur)="handleInputChange(formRows[i], word)"
+                (keydown.enter)="handleInputChange(formRows[i], word, $event)"
+              />
+              <mat-error *ngIf="formRows[i].get('name')?.hasError('required')">
+                Name is required.
+              </mat-error>
+              <mat-error *ngIf="formRows[i].get('name')?.hasError('notUnique')">
+                Name must be unique. Please choose a different name.
+              </mat-error>
+            </mat-form-field>
+          }
+        </mat-cell>
       </ng-container>
 
       <ng-container matColumnDef="description">
@@ -95,15 +124,10 @@
       </ng-container>
 
       <ng-container matColumnDef="delete">
-        <mat-header-cell *matHeaderCellDef></mat-header-cell>
-        <mat-cell *matCellDef="let element" class="delete-cell">
-          <button
-            class="text-red-500 bg-primary-alpha-5 hover:text-red-700 cursor-pointer hover:bg-red-50 rounded p-2"
-            (click)="deleteItem(element.id)"
-            [disabled]="true"
-          >
-            <!-- remove disabled true when implement Delete dictionary item -->
-            <em class="indicon-delete"></em>
+        <mat-header-cell *matHeaderCellDef>Delete</mat-header-cell>
+        <mat-cell *matCellDef="let element; let i = index">
+          <button mat-icon-button (click)="deleteItemFromTable(element.id, i)">
+            <mat-icon>delete</mat-icon>
           </button>
         </mat-cell>
       </ng-container>

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.scss
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.scss
@@ -27,8 +27,7 @@ mat-header-row {
     flex: 0 0 10%;
 }
 
-.delete-cell {
-  display: flex;
-  justify-content: flex-end;
-  padding-right: 6px;
+::ng-deep .mat-mdc-form-field-error-wrapper {
+  padding: 0 !important;
 }
+

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.ts
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-drawer/dictionary-drawer.component.ts
@@ -9,6 +9,7 @@ import {
 import { BehaviorSubject } from 'rxjs';
 import {
   DictionaryFull,
+  DictionaryFullItem,
   DictionaryListItem,
 } from '@/core/types/entities/dictionary.i';
 import { DictionaryService } from '@/core/services/dictionary/dictionary.service';
@@ -22,6 +23,21 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CardComponent } from '@/core/components/common/card/card.component';
 import { InputComponent } from '@/core/components/common/input/input.component';
+import { MatButtonModule } from '@angular/material/button';
+import { ButtonComponent } from '@/core/components/common/button/button.component';
+import {
+  AbstractControl,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+export interface UiDictionaryItem extends DictionaryFullItem {
+  validationError?: string;
+}
 
 @Component({
   selector: 'eln-dictionary-drawer',
@@ -37,6 +53,9 @@ import { InputComponent } from '@/core/components/common/input/input.component';
     CardComponent,
     InputComponent,
     MatProgressSpinnerModule,
+    MatButtonModule,
+    ButtonComponent,
+    ReactiveFormsModule,
   ],
   styleUrls: ['./dictionary-drawer.component.scss'],
   standalone: true,
@@ -46,7 +65,10 @@ export class DictionaryDrawerComponent implements OnChanges {
   @Output() close = new EventEmitter<void>();
 
   private dictionaryService = inject(DictionaryService);
-
+  private snackBar = inject(MatSnackBar);
+  private lastId: string | null = null;
+  /* Cache the original data to support filtering */
+  private originalData: UiDictionaryItem[] = [];
   dataSource$ = new BehaviorSubject<DictionaryFull>([]);
 
   displayedColumns: string[] = [
@@ -57,11 +79,12 @@ export class DictionaryDrawerComponent implements OnChanges {
     'createdAt',
     'delete',
   ];
-  private lastId: string | null = null;
+
   isLoadingDictionaryDetails = false;
 
-  /* Cache the original data to support filtering */
-  private originalData: DictionaryFull = [];
+  formRows: FormGroup[] = [];
+
+  constructor(private fb: FormBuilder) {}
 
   ngOnChanges(): void {
     if (this.dictionary) {
@@ -77,6 +100,14 @@ export class DictionaryDrawerComponent implements OnChanges {
     }
   }
 
+  /**
+   * Helper method to retrieve FormControl from FormGroup
+   * This ensures type safety when used in the template
+   */
+  getFormControl(form: FormGroup, controlName: string): FormControl {
+    return form.get(controlName) as FormControl;
+  }
+
   private getDictionaryDetails(): void {
     this.isLoadingDictionaryDetails = true;
     this.dictionaryService.getDictionaryDetails(this.dictionary!.id).subscribe({
@@ -84,6 +115,9 @@ export class DictionaryDrawerComponent implements OnChanges {
         this.originalData = response;
         this.dataSource$.next(response);
         this.isLoadingDictionaryDetails = false;
+        this.formRows = this.originalData.map((item) =>
+          this.createRowForm(item.name),
+        );
       },
       error: (err) => {
         console.error('Error fetching dictionary details:', err);
@@ -107,19 +141,128 @@ export class DictionaryDrawerComponent implements OnChanges {
     this.dataSource$.next(filteredData);
   }
 
-  deleteItem(itemId: string): void {
+  deleteItemFromTable(itemId: string | null, index: number): void {
+    if (!itemId) {
+      // new unsaved item, just remove from local data
+      this.originalData.splice(index, 1);
+      this.formRows.splice(index, 1);
+      this.dataSource$.next([...this.originalData]);
+    } else {
+      // existing item, call API to delete
+      this.dictionaryService
+        .deleteDictionaryItem(this.lastId, itemId)
+        .subscribe({
+          next: (updatedDictionary) => {
+            const deletedItem = this.originalData[index];
+            this.originalData = updatedDictionary;
+            this.dataSource$.next(updatedDictionary);
+            this.formRows.splice(index, 1);
+
+            this.snackBar.open(
+              `Word '${deletedItem.name}' has been successfully deleted.`,
+              'Close',
+              {
+                duration: 5000,
+              },
+            );
+          },
+          error: (err) => {
+            console.error('Error deleting dictionary item:', err);
+          },
+        });
+    }
+  }
+
+  addNewWordRowToTable(): void {
     if (!this.dictionary?.id) {
+      console.error('Dictionary ID is not available');
       return;
     }
 
-    this.dictionaryService
-      .deleteDictionaryItem(this.dictionary.id, itemId)
-      .subscribe({
-        next: (updatedDictionary) => {
-          this.originalData = updatedDictionary;
-          this.dataSource$.next(updatedDictionary);
-        },
-        error: (err) => console.error('Error deleting item:', err),
-      });
+    const currentDate = new Date();
+    const newItem = {
+      name: '',
+      description: '',
+      active: true,
+      ordinal:
+        this.originalData.length > 0
+          ? Math.max(...this.originalData.map((item) => item.ordinal)) + 1
+          : 1,
+      createdAt: currentDate,
+      id: '',
+      validationError: '',
+    };
+
+    this.originalData.push(newItem);
+    this.dataSource$.next([...this.originalData]);
+
+    this.formRows.push(this.createRowForm(newItem.name));
+  }
+
+  private createRowForm(name: string) {
+    return this.fb.group({
+      name: [
+        name,
+        [
+          Validators.required,
+          this.nameUniqueValidator.bind(this),
+          Validators.maxLength(256),
+        ],
+      ],
+    });
+  }
+
+  handleInputChange(rowForm: FormGroup, item: UiDictionaryItem, event?: Event) {
+    if (event && event.type === 'keydown') {
+      event.preventDefault();
+    }
+
+    const nameControl = rowForm.get('name');
+    if (nameControl) {
+      nameControl.updateValueAndValidity();
+    }
+    const updatedValues = rowForm.value;
+    const updatedItem = { ...item, ...updatedValues };
+
+    if (rowForm.valid) {
+      this.postNewWordToApi(rowForm, updatedItem);
+    }
+  }
+
+  postNewWordToApi(rowForm: FormGroup, item: DictionaryListItem) {
+    const formValue = rowForm.value;
+
+    if (!item.id) {
+      this.dictionaryService
+        .addDictionaryItem(this.lastId, formValue.name)
+        .subscribe({
+          next: (updatedDictionary) => {
+            this.originalData = updatedDictionary;
+            this.dataSource$.next(updatedDictionary);
+
+            const index = this.formRows.indexOf(rowForm);
+            if (index !== -1) {
+              const savedWord = updatedDictionary.find(
+                (entry) => entry.name === formValue.name,
+              );
+              if (savedWord) {
+                this.formRows[index] = this.createRowForm(savedWord.name);
+              }
+            }
+          },
+          error: (err) => {
+            console.error('Error adding dictionary item:', err);
+          },
+        });
+    }
+  }
+
+  private nameUniqueValidator(control: AbstractControl) {
+    const name = control.value;
+    const isDuplicate = this.originalData.some(
+      (item) => item.name.toLowerCase() === name.toLowerCase(),
+    );
+
+    return isDuplicate ? { notUnique: true } : null;
   }
 }

--- a/indigo-frontend/src/app/pages/dictionary/dictionary-layout/dictionary-layout.component.html
+++ b/indigo-frontend/src/app/pages/dictionary/dictionary-layout/dictionary-layout.component.html
@@ -2,8 +2,8 @@
   <mat-drawer
     mode="over"
     position="end"
-    [style.width.%]="60"
-    [style.min-width.px]="400"
+    [style.width.%]="70"
+    [style.min-width.px]="600"
     [style.boxShadow]="'0 8px 16px rgba(0, 0, 0, 0.2)'"
     [style.background]="'white'"
     [opened]="isDrawerOpen"

--- a/indigo-frontend/src/core/services/dictionary/dictionary.service.ts
+++ b/indigo-frontend/src/core/services/dictionary/dictionary.service.ts
@@ -29,4 +29,23 @@ export class DictionaryService {
       `dictionaries/${dictionaryId}/${itemId}`,
     );
   }
+
+addDictionaryItem(
+  dictionaryId: string,
+  name: string,
+  description = '',
+): Observable<DictionaryFull> {
+
+  const body: { name: string; description?: string } = { name };
+
+  if (description) {
+    body.description = description;
+  }
+
+  return this.api.request<DictionaryFull>(
+    'post',
+    `dictionaries/${dictionaryId}`,
+    body,
+  );
+}
 }


### PR DESCRIPTION
Closes [ng-274](https://github.com/epam/Indigo-ELN-v.-2.0/issues/274) and [ng-294](https://github.com/epam/Indigo-ELN-v.-2.0/issues/294)

**1) Add word (name) to dictionary (on name input blur or Enter keypress). User can delete temporary word on UI:**

<img width="1920" height="961" alt="Screenshot (1427)" src="https://github.com/user-attachments/assets/ee23bb4e-55f8-443f-b83d-6c04073f8da4" />

**2) validate user input:**
<img width="1920" height="974" alt="Screenshot (1426)" src="https://github.com/user-attachments/assets/30abc22f-94a1-422d-8ae4-9137c7ec26ab" />


**4) Delete existing word from dictionary (API call):**
<img width="1920" height="985" alt="Screenshot (1429)" src="https://github.com/user-attachments/assets/ab173401-cf08-48c3-b077-3066ef13c989" />
