### PR TITLE
feat (#280): add literature display to project info

### DIFF
--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
@@ -34,6 +34,11 @@
         </div>
       </div>
 
+      <div>
+        <h3 class="text-neutral-800 mb-2 font-semibold">Literature</h3>
+        <p class="text-neutral-1000">{{ project.literature || '-' }}</p>
+      </div>
+
       @if (project.description || project.details) {
       <div>
         <h3 class="text-neutral-800 mb-2 font-semibold">Project Details</h3>


### PR DESCRIPTION
Closes #280 
Verified and found that keywords are added now.
Added the missing `Literature` section to Project info tab:
<img width="425" height="296" alt="image" src="https://github.com/user-attachments/assets/14bf9ca3-34e7-46f3-9b5b-96ef67d50df0" />

