### PR TITLE
feat(256): [BUG] New notebook is not saved

### DIFF
--- a/indigo-frontend/src/app/pages/project/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/project/notebook/notebook-add/notebook-add.component.ts
@@ -80,7 +80,8 @@ export class NotebookAddComponent {
           this.dialogRef.close('refresh');
         }),
         catchError((createError) => {
-          this.snackBar.open(createError.error[0]?.message || createError.message || 'There was an error creating the notebook, please try again later.', 'Close', { duration: 5000 });
+          const errorMsg = createError.error[0]?.message || 'There was an error creating the notebook, please try again later.';
+          this.snackBar.open(errorMsg, 'Close', { duration: 5000 });
           return of(null);
         }),
       )

--- a/indigo-frontend/src/app/pages/project/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/project/notebook/notebook-add/notebook-add.component.ts
@@ -3,12 +3,14 @@ import { ApiService } from '@/core/services/api.service';
 import { Notebook } from '@/core/types/entities/notebook.i';
 import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
 import { catchError, of, tap } from 'rxjs';
+import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
 
 @Component({
   standalone: true,
@@ -25,6 +27,7 @@ import { catchError, of, tap } from 'rxjs';
 export class NotebookAddComponent {
   projectId: string;
   dialogRef = inject(MatDialogRef);
+  private snackBar = inject(MatSnackBar);
   fields: FormlyFieldConfig[] = [
     {
       type: 'input',
@@ -33,6 +36,22 @@ export class NotebookAddComponent {
         label: 'Notebook Name',
         placeholder: 'Notebook Name',
         required: true,
+        minLength: NOTEBOOK_NAME_LENGTH,
+        maxLength: NOTEBOOK_NAME_LENGTH,
+      },
+      validators: {
+        validation: [
+          Validators.required,
+          Validators.minLength(NOTEBOOK_NAME_LENGTH),
+          Validators.maxLength(NOTEBOOK_NAME_LENGTH),
+        ],
+      },
+      validation: {
+        messages: {
+          minlength: `Must be exactly ${NOTEBOOK_NAME_LENGTH} characters`,
+          maxlength: `Must be exactly ${NOTEBOOK_NAME_LENGTH} characters`,
+          required: 'Name is required',
+        },
       },
     },
     {
@@ -45,7 +64,7 @@ export class NotebookAddComponent {
     },
   ];
 
-  constructor(protected service: ApiService<Notebook>) {}
+  constructor(protected service: ApiService<Notebook>) { }
 
   createNotebook(data: Notebook) {
     this.service
@@ -61,7 +80,7 @@ export class NotebookAddComponent {
           this.dialogRef.close('refresh');
         }),
         catchError((createError) => {
-          alert(createError.message);
+          this.snackBar.open(createError.error[0]?.message || createError.message || 'There was an error creating the notebook, please try again later.', 'Close', { duration: 5000 });
           return of(null);
         }),
       )

--- a/indigo-frontend/src/core/components/common/form-dialog/form-dialog.component.html
+++ b/indigo-frontend/src/core/components/common/form-dialog/form-dialog.component.html
@@ -64,6 +64,7 @@
             <eln-button
               [type]="'button'"
               [variant]="'blue'"
+              [disabled]="form.invalid"
               (click)="submit()"
               >{{ submitButtonText }}</eln-button
             >


### PR DESCRIPTION
https://github.com/user-attachments/assets/8b5ab67f-42f5-4055-b90f-bc217677f1e7

Added guardrails for ensuring the user meets the name formation criteria + is only able to submit the notebook when the form is valid

<img width="1549" height="1022" alt="image" src="https://github.com/user-attachments/assets/e8014262-568e-45d5-86d5-1df7463bea8a" />
Message toast for communication in case of error (showing the BE human-readable error)