### PR TITLE
feat(295): [FE] Implement stoichiometry row

### DIFF
--- a/indigo-frontend/src/app/pages/experiment/sample-search/sample-search.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/sample-search/sample-search.component.ts
@@ -56,7 +56,6 @@ import { ToggleComponent } from '@core/components/common/toggle/toggle.component
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { StructureEditorModalComponent } from '@core/components/experiment/structure-editor-modal/structure-editor-modal.component';
 import { UUID } from '@core/types/entities/experiments/experiment-shared.i';
-import { MutateModelForm } from '@core/types/entities/experiments/experiment-mutate-form.i';
 import { ExperimentModelService } from '@core/services/experiment/experiment-model.service';
 import { ReactionAnchor } from '@core/types/entities/experiments/mutation.i';
 import { distinctUntilChanged } from 'rxjs';
@@ -248,18 +247,14 @@ export class SampleSearchComponent implements OnInit {
       this.experimentModelService,
       this.experimentModelService.experimentModel(),
     );
-    const payload: MutateModelForm = {
-      model: this.experimentModelService.experimentModel(),
-      mutation: {
-        type: 'AddInput',
-
-        anchor: this.reactionAnchor,
-        sampleId: sample.id,
-      },
+    const mutation = {
+      type: 'AddInput' as const,
+      anchor: this.reactionAnchor,
+      sampleId: sample.id,
     };
 
     this.experimentModelService
-      .updateDataModel(this.experimentId, payload)
+      .updateDataModel(mutation)
       .subscribe({
         next: () => {
           console.log('Model updated with new sample');

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-inputs-table/reaction-inputs-table.component.html
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-inputs-table/reaction-inputs-table.component.html
@@ -29,10 +29,10 @@
 
         <!-- Select -->
         <mat-select *ngIf="column.type === ColumnInputType.SELECT" hideSingleSelectionIndicator
-          class="!w-full !h-full !text-xs" [value]="column.field(row)" [disabled]="!(column.editable?.(row) ?? true)"
-          (selectionChange)="column.onSave?.(row, $event.value)">
-          @for (role of REACTION_ROLES; track role) {
-          <mat-option [value]="role" style="font-size: 0.8rem">{{ getReactionRoleDisplayName(role) }}</mat-option>
+          class="!w-full !h-full !text-xs capitalize" [value]="column.field(row)"
+          [disabled]="!(column.editable?.(row) ?? true)" (selectionChange)="column.onSave?.(row, $event.value)">
+          @for (option of column.options; track option.id) {
+          <mat-option [value]="option.id" style="font-size: 0.8rem" class="capitalize">{{ option.name }}</mat-option>
           }
         </mat-select>
 
@@ -58,11 +58,22 @@
         </div>
 
         <!-- Multi-Select -->
-        <mat-select *ngIf="column.type === ColumnInputType.MULTI_SELECT" multiple hideSingleSelectionIndicator
-          class="w-full h-full text-xs" [style.width]="column.style?.width" [value]="column.field(row)"
-          [disabled]="!(column.editable?.(row) ?? true)" (selectionChange)="column.onSave?.(row, $event.value)">
+        <mat-select #multiSelect *ngIf="column.type === ColumnInputType.MULTI_SELECT" multiple
+          hideSingleSelectionIndicator class="!w-full !h-full !text-xs capitalize" [value]="column.field(row)"
+          [compareWith]="compareDictionaryItems" [disabled]="!(column.editable?.(row) ?? true)"
+          (openedChange)="!$event && column.onSave?.(row, multiSelect.value)">
+          <mat-select-trigger>
+            <div class="flex items-center gap-1 min-h-6 overflow-x-auto no-scrollbar pr-4">
+              @for (hazard of multiSelect.value; track hazard.id) {
+              <span
+                class="px-1.5 py-0.5 rounded-full bg-primary-50 text-primary-700 border border-primary-200 text-[0.65rem] whitespace-nowrap">
+                {{ hazard.name }}
+              </span>
+              }
+            </div>
+          </mat-select-trigger>
           @for (option of column.options; track option.id) {
-          <mat-option [value]="option" style="font-size: 0.8rem">{{ option.name }}</mat-option>
+          <mat-option [value]="option" style="font-size: 0.8rem" class="capitalize">{{ option.name }}</mat-option>
           }
         </mat-select>
       </td>

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-inputs-table/reaction-inputs-table.component.html
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-inputs-table/reaction-inputs-table.component.html
@@ -1,37 +1,81 @@
-<h3 class="text-sm font-semibold p-3">Reactants, Reagents, Solvents</h3>
+<div class="flex justify-between py-1">
+  <h3 class="text-sm font-semibold p-3">Reactants, Reagents, Solvents</h3>
+  <div class="flex justify-between items-center">
+    <eln-button (click)="addNewRow()" variant="grey">
+      <mat-icon class="text-md">add</mat-icon>
+    </eln-button>
+  </div>
+</div>
 <div class="w-full overflow-x-auto border border-gray-300 rounded">
-  <table mat-table [dataSource]="dataSource()" class="w-full bg-white">
-      @for (column of columns; track column.id) {
-        <ng-container [matColumnDef]="column.id">
-          <th 
-            mat-header-cell 
-            *matHeaderCellDef 
-            class="text-left !font-bold text-xs text-gray-900 p-1 border-b border-r !border-gray-200 last:border-r-0 max-w-sm overflow-hidden text-ellipsis whitespace-nowrap"
-          >
-            {{ column.header }}
-          </th>
-          <td 
-            mat-cell 
-            *matCellDef="let row" 
-            class="text-xs text-gray-900 p-1 border-b border-r !border-gray-200 last:border-r-0 last:border-b-0 max-w-sm overflow-hidden text-ellipsis whitespace-nowrap"
-          >
-            @switch (column.type) {
-              <!-- TODO add other input types logic and column definitions -->
-              @case ('text') {
-                {{ column.field(row) || '–' }}
-              }
+  <table mat-table [dataSource]="dataSource()" class="w-full" style="background-color: white;">
+    @for (column of columns(); track column.id) {
+    <ng-container [matColumnDef]="column.id">
+      <th mat-header-cell *matHeaderCellDef
+        class="text-left !font-bold text-xs text-gray-900 p-1 border-b border-r !border-gray-200 last:border-r-0 min-w-32 overflow-hidden text-ellipsis whitespace-nowrap">
+        {{ column.header }}
+      </th>
+      <td mat-cell *matCellDef="let row"
+        class="text-xs p-0 border-b border-r !border-gray-200 min-w-32 overflow-visible" style="color: #3F50B5;">
+
+        <!-- Text Input -->
+        <input *ngIf="column.type === ColumnInputType.TEXT" type="text" placeholder="—" matInput style="outline: none;"
+          [value]="column.field(row) || ''" [disabled]="!(column.editable?.(row) ?? true)"
+          (blur)="column.onSave?.(row, $event)" (keydown.enter)="column.onSave?.(row, $event)" />
+
+        <!-- Number Input -->
+        <input *ngIf="column.type === ColumnInputType.NUMBER" type="number" placeholder="—" style="outline: none;"
+          [value]="column.field(row) || ''" [disabled]="!(column.editable?.(row) ?? true)"
+          (blur)="column.onSave?.(row, $event)" (keydown.enter)="column.onSave?.(row, $event)" />
+
+        <!-- Select -->
+        <mat-select *ngIf="column.type === ColumnInputType.SELECT" hideSingleSelectionIndicator
+          class="!w-full !h-full !text-xs" [value]="column.field(row)" [disabled]="!(column.editable?.(row) ?? true)"
+          (selectionChange)="column.onSave?.(row, $event.value)">
+          @for (role of REACTION_ROLES; track role) {
+          <mat-option [value]="role" style="font-size: 0.8rem">{{ getReactionRoleDisplayName(role) }}</mat-option>
+          }
+        </mat-select>
+
+        <!-- Checkbox -->
+        <input *ngIf="column.type === ColumnInputType.CHECKBOX" type="checkbox" [checked]="column.field(row)"
+          [disabled]="!(column.editable?.(row) ?? true)" (change)="column.onSave?.(row, $event)" />
+
+        <!-- Unit Input (weight, volume, etc) -->
+        <div *ngIf="column.type === ColumnInputType.UNIT_INPUT" class="flex w-full h-full">
+          @let unitField = toUnitField(column.field(row));
+          <input #valueInput type="number" matInput placeholder="—" style="outline: none;"
+            [value]="unitField?.value ?? ''" [disabled]="!(column.editable?.(row) ?? true)"
+            (blur)="column.onSave?.(row, { value: $any($event.target).valueAsNumber, unit: unitField?.unit })"
+            (keydown.enter)="column.onSave?.(row, { value: $any($event.target).valueAsNumber, unit: unitField?.unit })" />
+          <mat-divider vertical style="opacity: 0.3;" />
+          <mat-select class="!h-full !text-xs" hideSingleSelectionIndicator style="min-width: 4rem; text-align: center;"
+            [value]="unitField?.unit" [disabled]="!(column.editable?.(row) ?? true)"
+            (selectionChange)="column.onSave?.(row, { value: valueInput.valueAsNumber, unit: $event.value })">
+            @for (unit of column.options; track unit.id) {
+            <mat-option [value]="unit.id" style="font-size: 0.8rem;">{{ unit.name }}</mat-option>
             }
-          </td>
-        </ng-container>
-      }
+          </mat-select>
+        </div>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns" class="h-8 bg-white"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="h-10 bg-white hover:!bg-gray-50"></tr>
-    </table>
-
-    @if (dataSource().length === 0) {
-      <div class="flex flex-col items-center justify-center py-12 text-gray-600 border-t border-gray-300">
-        <div class="text-sm">No material added</div>
-      </div>
+        <!-- Multi-Select -->
+        <mat-select *ngIf="column.type === ColumnInputType.MULTI_SELECT" multiple hideSingleSelectionIndicator
+          class="w-full h-full text-xs" [style.width]="column.style?.width" [value]="column.field(row)"
+          [disabled]="!(column.editable?.(row) ?? true)" (selectionChange)="column.onSave?.(row, $event.value)">
+          @for (option of column.options; track option.id) {
+          <mat-option [value]="option" style="font-size: 0.8rem">{{ option.name }}</mat-option>
+          }
+        </mat-select>
+      </td>
+    </ng-container>
     }
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns()" class="h-8 bg-white"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns()" class="h-10 bg-white hover:!bg-gray-50"></tr>
+  </table>
+
+  @if (dataSource().length === 0) {
+  <div class="flex flex-col items-center justify-center py-12 text-gray-600 border-t border-gray-300">
+    <div class="text-sm">No material added</div>
+  </div>
+  }
 </div>

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-inputs-table/reaction-inputs-table.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-inputs-table/reaction-inputs-table.component.ts
@@ -30,7 +30,7 @@ import {
 } from '@angular/material/table';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSelect, MatOption } from '@angular/material/select';
+import { MatSelect, MatOption, MatSelectTrigger } from '@angular/material/select';
 import { MatInput } from '@angular/material/input';
 import { MatDivider } from '@angular/material/divider';
 import { FormsModule } from '@angular/forms';
@@ -55,7 +55,7 @@ interface InputSampleRow {
 
 interface UnitFieldValue { value: number | string; unit: string; }
 
-type FieldValue = string | null | boolean | UnitFieldValue;
+type FieldValue = string | null | boolean | UnitFieldValue | DictionaryItemRef[];
 
 interface UnitInputChange {
   value?: number | null;
@@ -75,9 +75,6 @@ interface ColumnConfig {
   editable?: (row: InputSampleRow) => boolean;
   onSave?: (row: InputSampleRow, payload?: unknown) => void;
   options?: ColumnOption[] | DictionaryItemRef[]; // For select and multi-select columns
-  style?: {
-    width?: string; // Width applied to the input field
-  };
 }
 
 @Component({
@@ -97,6 +94,7 @@ interface ColumnConfig {
     MatSnackBarModule,
     MatIconModule,
     MatSelect,
+    MatSelectTrigger,
     MatOption,
     MatInput,
     MatDivider,
@@ -132,8 +130,6 @@ export class ReactionInputsTableComponent implements OnInit {
     this.builtInDictionaryService.load(BuiltInDictionary.HEALTH_HAZARD);
   }
 
-  readonly REACTION_ROLES = Object.values(ReactionRole);
-
   readonly columns = computed<ColumnConfig[]>(() => [
     {
       id: 'compoundId',
@@ -146,7 +142,7 @@ export class ReactionInputsTableComponent implements OnInit {
       id: 'casNumber',
       header: 'CAS Number',
       type: ColumnInputType.TEXT,
-      field: () => null, // TODO add it to CompoundRef
+      field: (row: InputSampleRow) => row.input.compound.casNumber,
       editable: () => false,
     },
     {
@@ -161,7 +157,7 @@ export class ReactionInputsTableComponent implements OnInit {
       id: 'nbkBatch',
       header: 'NBK Batch #',
       type: ColumnInputType.TEXT,
-      field: () => null, // TODO add it to CompoundRef
+      field: (row: InputSampleRow) => row.sample.nbkBatchNumber,
       editable: () => false,
     },
     {
@@ -169,7 +165,7 @@ export class ReactionInputsTableComponent implements OnInit {
       header: 'Mol. Weight',
       type: ColumnInputType.NUMBER,
       field: (row: InputSampleRow) => row.input.compound.molWeight?.value?.toString(),
-      editable: (row: InputSampleRow) => 'type' in row.input.compound && row.input.compound.type === CompoundType.UNKNOWN, // TODO CompoundRef has no type property, only children do, what to do here?
+      editable: (row: InputSampleRow) => row.input.compound.type === CompoundType.UNKNOWN,
       onSave: (row: InputSampleRow, event: Event) => {
         const value = +(event.target as HTMLInputElement).value;
         const previousState = structuredClone(this.experimentModelService.experimentModel());
@@ -228,12 +224,12 @@ export class ReactionInputsTableComponent implements OnInit {
       header: 'Mol',
       type: ColumnInputType.UNIT_INPUT,
       field: (row: InputSampleRow) =>
-        row.input.mol?.value ? { value: row.input.mol.value, unit: row.input.mol.unit } : null,
+        row.sample.mol?.value ? { value: row.sample.mol.value, unit: row.sample.mol.unit } : null,
       onSave: (row: InputSampleRow, payload?: unknown) => {
         this.applyUnitInputChange(payload as UnitInputChange, (value, unit) => {
           return this.experimentModelService.updateDataModel({
             type: 'SetInputMol',
-            anchor: row.input.anchor,
+            anchor: row.sample.anchor,
             mol: value,
             unit: unit as MolUnit,
           });
@@ -291,6 +287,10 @@ export class ReactionInputsTableComponent implements OnInit {
           error: (error) => this.handleUpdateError(error, previousState),
         });
       },
+      options: Object.values(ReactionRole).map(role => ({
+        id: role,
+        name: role.toLocaleLowerCase(),
+      })) as ColumnOption[],
     },
     {
       id: 'density',
@@ -362,7 +362,7 @@ export class ReactionInputsTableComponent implements OnInit {
       header: 'Salt Code',
       type: ColumnInputType.SELECT,
       field: (row: InputSampleRow) => row.input.compound.saltCode?.name ?? null,
-      editable: (row: InputSampleRow) => 'type' in row.input.compound && row.input.compound.type === CompoundType.VIRTUAL, // TODO CompoundRef has no type property, only children do, what to do here?
+      editable: (row: InputSampleRow) => row.input.compound.type === CompoundType.VIRTUAL,
       onSave: (row: InputSampleRow, selectedSaltCode: unknown) => {
         const previousState = structuredClone(this.experimentModelService.experimentModel());
 
@@ -398,20 +398,19 @@ export class ReactionInputsTableComponent implements OnInit {
       id: 'hazardComments',
       header: 'Hazard Comments',
       type: ColumnInputType.MULTI_SELECT,
-      field: (row: InputSampleRow) => row.sample.healthHazard?.map((h) => h.name).join(', ') ?? 'None',
+      field: (row: InputSampleRow) => row.sample.healthHazards ?? [],
       onSave: (row: InputSampleRow, selectedHazards: unknown[]) => {
         const previousState = structuredClone(this.experimentModelService.experimentModel());
 
         this.experimentModelService.updateDataModel({
           type: 'SetInputHealthHazards',
-          anchor: row.input.anchor,
+          anchor: row.sample.anchor,
           healthHazards: selectedHazards as DictionaryItemRef[],
         }).subscribe({
           error: (error) => this.handleUpdateError(error, previousState),
         });
       },
       options: this.healthHazards(),
-      style: { width: '10rem' },
     },
     {
       id: 'comments',
@@ -435,23 +434,16 @@ export class ReactionInputsTableComponent implements OnInit {
 
   displayedColumns = computed(() => this.columns().map((col) => col.id));
 
+  compareDictionaryItems = (a?: DictionaryItemRef | null, b?: DictionaryItemRef | null) =>
+    !!a && !!b ? a.id === b.id : a === b;
+
   getInputType(columnId: string): ColumnInputType {
     const column = this.columns().find(c => c.id === columnId);
     return column?.type ?? ColumnInputType.TEXT;
   }
 
-  getReactionRoleDisplayName(role: string): string {
-    const roleMap: Record<string, string> = {
-      [ReactionRole.REACTANT]: 'Reactant',
-      [ReactionRole.CATALYST]: 'Catalyst',
-      [ReactionRole.SOLVENT]: 'Solvent',
-      [ReactionRole.OUTPUT]: 'Output',
-    };
-    return roleMap[role] ?? role;
-  }
-
   toUnitField(fieldValue: FieldValue): UnitFieldValue | null {
-    return fieldValue && typeof fieldValue !== 'string' && typeof fieldValue !== 'boolean' ? fieldValue : null;
+    return fieldValue && typeof fieldValue !== 'string' && typeof fieldValue !== 'boolean' && !Array.isArray(fieldValue) ? fieldValue : null;
   }
 
   private applyUnitInputChange(

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-inputs-table/reaction-inputs-table.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-inputs-table/reaction-inputs-table.component.ts
@@ -1,18 +1,21 @@
-import { Component, computed, inject, input } from '@angular/core';
+import { Component, computed, inject, input, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Observable } from 'rxjs';
 import {
   Reaction,
   ReactionInput,
+  ReactionInputSample,
+  ExperimentModel,
 } from '@core/types/entities/experiments/experiment.i';
 import {
   DensityUnit,
   MolarityUnit,
   MolUnit,
-  NoUnit,
   ReactionRole,
   VolumeUnit,
   WeightUnit,
 } from '@core/types/entities/experiments/experiment-shared.i';
-import { EnteredValue } from '@core/types/entities/values.i';
+import { DictionaryItemRef, BuiltInDictionary } from '@core/types/entities/dictionary.i';
 import {
   MatCell,
   MatCellDef,
@@ -25,7 +28,57 @@ import {
   MatRowDef,
   MatTable,
 } from '@angular/material/table';
-import { ExperimentService } from '@core/services/experiment/experiment.service';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelect, MatOption } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
+import { MatDivider } from '@angular/material/divider';
+import { FormsModule } from '@angular/forms';
+import { ExperimentModelService } from '@core/services/experiment/experiment-model.service';
+import { BuiltInDictionaryService } from '@core/services/health-hazards/built-in-dictionary.service';
+import { ButtonComponent } from '@core/components/common/button/button.component';
+import { CompoundType } from '@/core/types/entities/compound.i';
+
+enum ColumnInputType {
+  TEXT = 'text',
+  NUMBER = 'number',
+  SELECT = 'select',
+  CHECKBOX = 'checkbox',
+  UNIT_INPUT = 'unit-input',
+  MULTI_SELECT = 'multi-select',
+}
+
+interface InputSampleRow {
+  input: ReactionInput;
+  sample: ReactionInputSample;
+}
+
+interface UnitFieldValue { value: number | string; unit: string; }
+
+type FieldValue = string | null | boolean | UnitFieldValue;
+
+interface UnitInputChange {
+  value?: number | null;
+  unit?: string | null;
+}
+
+interface ColumnOption {
+  id: string;
+  name: string;
+}
+
+interface ColumnConfig {
+  id: string;
+  header: string;
+  type: ColumnInputType;
+  field: (row: InputSampleRow) => FieldValue;
+  editable?: (row: InputSampleRow) => boolean;
+  onSave?: (row: InputSampleRow, payload?: unknown) => void;
+  options?: ColumnOption[] | DictionaryItemRef[]; // For select and multi-select columns
+  style?: {
+    width?: string; // Width applied to the input field
+  };
+}
 
 @Component({
   selector: 'eln-reaction-inputs-table',
@@ -41,216 +94,407 @@ import { ExperimentService } from '@core/services/experiment/experiment.service'
     MatHeaderRowDef,
     MatRow,
     MatRowDef,
+    MatSnackBarModule,
+    MatIconModule,
+    MatSelect,
+    MatOption,
+    MatInput,
+    MatDivider,
+    FormsModule,
+    CommonModule,
+    ButtonComponent,
   ],
 })
-export class ReactionInputsTableComponent {
-  private experimentService = inject(ExperimentService);
+export class ReactionInputsTableComponent implements OnInit {
+  private experimentModelService = inject(ExperimentModelService);
+  private builtInDictionaryService = inject(BuiltInDictionaryService);
+  private snackBar = inject(MatSnackBar);
+
+  readonly ColumnInputType = ColumnInputType;
 
   reaction = input<Reaction | null>(null);
-  dataSource = computed(() => this.reaction()?.inputs ?? []);
+  experimentId = input<string | null>(null);
+  dataSource = computed(() => {
+    const inputs = this.reaction()?.inputs ?? [];
+    return inputs.flatMap(input =>
+      input.samples.map(sample => ({ input, sample }))
+    );
+  });
+  healthHazards = computed(() =>
+    this.builtInDictionaryService.getDictionaryItems(BuiltInDictionary.HEALTH_HAZARD),
+  );
+  saltCodes = computed(() => {
+    // TODO: Load from API when available
+    return [] as DictionaryItemRef[];
+  });
 
-  columns = [
+  ngOnInit() {
+    this.builtInDictionaryService.load(BuiltInDictionary.HEALTH_HAZARD);
+  }
+
+  readonly REACTION_ROLES = Object.values(ReactionRole);
+
+  readonly columns = computed<ColumnConfig[]>(() => [
     {
       id: 'compoundId',
       header: 'Compound ID',
-      type: 'text',
-      field: (row: ReactionInput) => row.compound.strCode || row.anchor,
+      type: ColumnInputType.TEXT,
+      field: (row: InputSampleRow) => row.input.compound.strCode,
+      editable: () => false,
     },
     {
       id: 'casNumber',
       header: 'CAS Number',
-      type: 'text',
-      field: () => null,
+      type: ColumnInputType.TEXT,
+      field: () => null, // TODO add it to CompoundRef
+      editable: () => false,
     },
     {
       id: 'chemicalName',
       header: 'Chemical Name',
-      type: 'text',
-      field: () => null,
+      type: ColumnInputType.TEXT,
+      field: (row: InputSampleRow) => row.sample.chemicalName,
+      editable: () => false,
+      onSave: () => { /* TODO add mutation for chemical name */ },
     },
     {
       id: 'nbkBatch',
       header: 'NBK Batch #',
-      type: 'text',
-      field: () => null,
+      type: ColumnInputType.TEXT,
+      field: () => null, // TODO add it to CompoundRef
+      editable: () => false,
     },
     {
       id: 'molWeight',
       header: 'Mol. Weight',
-      type: 'text',
-      field: (row: ReactionInput) =>
-        row.compound.molWeight?.value
-          ? `${row.compound.molWeight.value} ${row.compound.molWeight?.unit}`
-          : null,
+      type: ColumnInputType.NUMBER,
+      field: (row: InputSampleRow) => row.input.compound.molWeight?.value?.toString(),
+      editable: (row: InputSampleRow) => 'type' in row.input.compound && row.input.compound.type === CompoundType.UNKNOWN, // TODO CompoundRef has no type property, only children do, what to do here?
+      onSave: (row: InputSampleRow, event: Event) => {
+        const value = +(event.target as HTMLInputElement).value;
+        const previousState = structuredClone(this.experimentModelService.experimentModel());
+
+        this.experimentModelService.updateDataModel({
+          type: 'SetInputCompoundMolWeight',
+          anchor: row.input.anchor,
+          molWeight: value || null,
+        }).subscribe({
+          error: (error) => this.handleUpdateError(error, previousState),
+        });
+      },
     },
     {
       id: 'weight',
       header: 'Weight',
-      type: 'text',
-      field: (row: ReactionInput) =>
-        row.samples[0]?.weight?.value
-          ? `${row.samples[0].weight.value} ${row.samples[0].weight.unit}`
+      type: ColumnInputType.UNIT_INPUT,
+      field: (row: InputSampleRow) =>
+        row.sample.weight?.value
+          ? { value: row.sample.weight.value, unit: row.sample.weight.unit }
           : null,
+      onSave: (row: InputSampleRow, payload?: unknown) => {
+        this.applyUnitInputChange(payload as UnitInputChange, (value, unit) => {
+          return this.experimentModelService.updateDataModel({
+            type: 'SetInputWeight',
+            anchor: row.sample.anchor,
+            weight: value,
+            unit: unit as WeightUnit,
+          });
+        });
+      },
+      options: Object.values(WeightUnit).map(unit => ({ id: unit, name: unit })) as ColumnOption[],
     },
     {
       id: 'volume',
       header: 'Volume',
-      type: 'text',
-      field: (row: ReactionInput) =>
-        row.samples[0]?.volume?.value
-          ? `${row.samples[0].volume.value} ${row.samples[0].volume.unit}`
+      type: ColumnInputType.UNIT_INPUT,
+      field: (row: InputSampleRow) =>
+        row.sample.volume?.value
+          ? { value: row.sample.volume.value, unit: row.sample.volume.unit }
           : null,
+      onSave: (row: InputSampleRow, payload?: unknown) => {
+        this.applyUnitInputChange(payload as UnitInputChange, (value, unit) => {
+          return this.experimentModelService.updateDataModel({
+            type: 'SetInputVolume',
+            anchor: row.sample.anchor,
+            volume: value,
+            unit: unit as VolumeUnit,
+          });
+        });
+      },
+      options: Object.values(VolumeUnit).map(unit => ({ id: unit, name: unit })) as ColumnOption[],
     },
     {
       id: 'mol',
       header: 'Mol',
-      type: 'text',
-      field: (row: ReactionInput) =>
-        row.mol?.value ? `${row.mol.value} ${row.mol.unit}` : null,
+      type: ColumnInputType.UNIT_INPUT,
+      field: (row: InputSampleRow) =>
+        row.input.mol?.value ? { value: row.input.mol.value, unit: row.input.mol.unit } : null,
+      onSave: (row: InputSampleRow, payload?: unknown) => {
+        this.applyUnitInputChange(payload as UnitInputChange, (value, unit) => {
+          return this.experimentModelService.updateDataModel({
+            type: 'SetInputMol',
+            anchor: row.input.anchor,
+            mol: value,
+            unit: unit as MolUnit,
+          });
+        });
+      },
+      options: Object.values(MolUnit).map(unit => ({ id: unit, name: unit })) as ColumnOption[],
     },
     {
       id: 'eq',
       header: 'EQ',
-      type: 'text',
-      field: (row: ReactionInput) => row.eq?.value?.toString(),
+      type: ColumnInputType.NUMBER,
+      field: (row: InputSampleRow) => row.input.eq?.value?.toString(),
+      onSave: (row: InputSampleRow, event: Event) => {
+        const value = +(event.target as HTMLInputElement).value;
+        const previousState = structuredClone(this.experimentModelService.experimentModel());
+
+        this.experimentModelService.updateDataModel({
+          type: 'SetInputRowEQ',
+          anchor: row.input.anchor,
+          eq: value,
+        }).subscribe({
+          error: (error) => this.handleUpdateError(error, previousState),
+        });
+      },
     },
     {
       id: 'limiting',
       header: 'Limiting',
-      type: 'text',
-      field: (row: ReactionInput) => (row.limiting ? '✓' : null), //
+      type: ColumnInputType.CHECKBOX,
+      field: (row: InputSampleRow) => row.input.limiting,
+      onSave: (row: InputSampleRow) => {
+        const previousState = structuredClone(this.experimentModelService.experimentModel());
+
+        this.experimentModelService.updateDataModel({
+          type: 'SetInputRowLimiting',
+          anchor: row.input.anchor,
+        }).subscribe({
+          error: (error) => this.handleUpdateError(error, previousState),
+        });
+      },
     },
     {
       id: 'rxnRole',
       header: 'Rxn Role',
-      type: 'text',
-      field: (row: ReactionInput) => row.role || 'REACTANT',
+      type: ColumnInputType.SELECT,
+      field: (row: InputSampleRow) => row.input.role,
+      onSave: (row: InputSampleRow, value: ReactionRole) => {
+        const previousState = structuredClone(this.experimentModelService.experimentModel());
+
+        this.experimentModelService.updateDataModel({
+          type: 'SetInputRowRole',
+          anchor: row.input.anchor,
+          role: value,
+        }).subscribe({
+          error: (error) => this.handleUpdateError(error, previousState),
+        });
+      },
     },
     {
       id: 'density',
       header: 'Density',
-      type: 'text',
-      field: (row: ReactionInput) =>
-        row.samples[0]?.density?.value
-          ? `${row.samples[0].density.value} ${row.samples[0].density.unit}`
+      type: ColumnInputType.UNIT_INPUT,
+      field: (row: InputSampleRow) =>
+        row.sample.density?.value
+          ? { value: row.sample.density.value, unit: row.sample.density.unit }
           : null,
+      onSave: (row: InputSampleRow, payload?: unknown) => {
+        this.applyUnitInputChange(payload as UnitInputChange, (value, unit) => {
+          return this.experimentModelService.updateDataModel({
+            type: 'SetInputDensity',
+            anchor: row.sample.anchor,
+            density: value,
+            unit: unit as DensityUnit,
+          });
+        });
+      },
+      options: Object.values(DensityUnit).map(unit => ({ id: unit, name: unit })) as ColumnOption[],
     },
     {
       id: 'molarity',
       header: 'Molarity',
-      type: 'text',
-      field: (row: ReactionInput) =>
-        row.samples[0]?.molarity?.value
-          ? `${row.samples[0].molarity.value} ${row.samples[0].molarity.unit}`
+      type: ColumnInputType.UNIT_INPUT,
+      field: (row: InputSampleRow) =>
+        row.sample.molarity?.value
+          ? { value: row.sample.molarity.value, unit: row.sample.molarity.unit }
           : null,
+      onSave: (row: InputSampleRow, payload?: unknown) => {
+        this.applyUnitInputChange(payload as UnitInputChange, (value, unit) => {
+          return this.experimentModelService.updateDataModel({
+            type: 'SetInputMolarity',
+            anchor: row.sample.anchor,
+            molarity: value,
+            unit: unit as MolarityUnit,
+          });
+        });
+      },
+      options: Object.values(MolarityUnit).map(unit => ({ id: unit, name: unit })) as ColumnOption[],
     },
     {
       id: 'purity',
       header: 'Purity',
-      type: 'text',
-      field: (row: ReactionInput) => row.samples[0]?.purity?.value?.toString(),
+      type: ColumnInputType.NUMBER,
+      field: (row: InputSampleRow) => row.sample.purity?.value?.toString(),
+      onSave: (row: InputSampleRow, event: Event) => {
+        const value = +(event.target as HTMLInputElement).value;
+        const previousState = structuredClone(this.experimentModelService.experimentModel());
+
+        this.experimentModelService.updateDataModel({
+          type: 'SetInputPurity',
+          anchor: row.sample.anchor,
+          purity: value,
+        }).subscribe({
+          error: (error) => this.handleUpdateError(error, previousState),
+        });
+      },
     },
     {
       id: 'molFormula',
       header: 'Mol Formula',
-      type: 'text',
-      field: (row: ReactionInput) => row.compound.formula,
+      type: ColumnInputType.TEXT,
+      field: (row: InputSampleRow) => row.input.compound.formula,
+      editable: () => false, // TODO define if editable or not
     },
     {
       id: 'saltCode',
       header: 'Salt Code',
-      type: 'text',
-      field: (row: ReactionInput) => row.compound.saltCode?.code,
+      type: ColumnInputType.SELECT,
+      field: (row: InputSampleRow) => row.input.compound.saltCode?.name ?? null,
+      editable: (row: InputSampleRow) => 'type' in row.input.compound && row.input.compound.type === CompoundType.VIRTUAL, // TODO CompoundRef has no type property, only children do, what to do here?
+      onSave: (row: InputSampleRow, selectedSaltCode: unknown) => {
+        const previousState = structuredClone(this.experimentModelService.experimentModel());
+
+        this.experimentModelService.updateDataModel({
+          type: 'SetInputRowSaltCode',
+          anchor: row.input.anchor,
+          saltCode: selectedSaltCode as DictionaryItemRef | null,
+        }).subscribe({
+          error: (error) => this.handleUpdateError(error, previousState),
+        });
+      },
+      options: this.saltCodes(),
     },
     {
       id: 'saltEQ',
       header: 'Salt EQ',
-      type: 'text',
-      field: (row: ReactionInput) => row.compound.saltEQ?.toString(),
+      type: ColumnInputType.TEXT,
+      field: (row: InputSampleRow) => row.input.compound.saltEQ?.toString(),
+      onSave: (row: InputSampleRow, event: Event) => {
+        const value = +(event.target as HTMLInputElement).value;
+        const previousState = structuredClone(this.experimentModelService.experimentModel());
+
+        this.experimentModelService.updateDataModel({
+          type: 'SetInputRowSaltEQ',
+          anchor: row.input.anchor,
+          saltEQ: value || null,
+        }).subscribe({
+          error: (error) => this.handleUpdateError(error, previousState),
+        });
+      },
     },
     {
       id: 'hazardComments',
       header: 'Hazard Comments',
-      type: 'text',
-      field: (row: ReactionInput) =>
-        row.samples[0]?.healthHazard?.map((h) => h.name).join(', '),
+      type: ColumnInputType.MULTI_SELECT,
+      field: (row: InputSampleRow) => row.sample.healthHazard?.map((h) => h.name).join(', ') ?? 'None',
+      onSave: (row: InputSampleRow, selectedHazards: unknown[]) => {
+        const previousState = structuredClone(this.experimentModelService.experimentModel());
+
+        this.experimentModelService.updateDataModel({
+          type: 'SetInputHealthHazards',
+          anchor: row.input.anchor,
+          healthHazards: selectedHazards as DictionaryItemRef[],
+        }).subscribe({
+          error: (error) => this.handleUpdateError(error, previousState),
+        });
+      },
+      options: this.healthHazards(),
+      style: { width: '10rem' },
     },
     {
       id: 'comments',
       header: 'Comments',
-      type: 'text',
-      field: () => null,
+      type: ColumnInputType.TEXT,
+      field: (row: InputSampleRow) => row.sample.comment ?? null,
+      onSave: (row: InputSampleRow, event: Event) => {
+        const value = (event.target as HTMLInputElement).value;
+        const previousState = structuredClone(this.experimentModelService.experimentModel());
+
+        this.experimentModelService.updateDataModel({
+          type: 'SetInputComment',
+          anchor: row.sample.anchor,
+          comment: value || null,
+        }).subscribe({
+          error: (error) => this.handleUpdateError(error, previousState),
+        });
+      },
     },
-  ];
+  ]);
 
-  displayedColumns = this.columns.map((col) => col.id);
+  displayedColumns = computed(() => this.columns().map((col) => col.id));
 
-  setRole(row: ReactionInput, value: ReactionRole) {
-    this.experimentService.mutateModel({
-      type: 'SetInputRowRole',
-      anchor: row.anchor,
-      role: value,
+  getInputType(columnId: string): ColumnInputType {
+    const column = this.columns().find(c => c.id === columnId);
+    return column?.type ?? ColumnInputType.TEXT;
+  }
+
+  getReactionRoleDisplayName(role: string): string {
+    const roleMap: Record<string, string> = {
+      [ReactionRole.REACTANT]: 'Reactant',
+      [ReactionRole.CATALYST]: 'Catalyst',
+      [ReactionRole.SOLVENT]: 'Solvent',
+      [ReactionRole.OUTPUT]: 'Output',
+    };
+    return roleMap[role] ?? role;
+  }
+
+  toUnitField(fieldValue: FieldValue): UnitFieldValue | null {
+    return fieldValue && typeof fieldValue !== 'string' && typeof fieldValue !== 'boolean' ? fieldValue : null;
+  }
+
+  private applyUnitInputChange(
+    change: UnitInputChange,
+    mutator: (value: number | undefined, unit: string | undefined) => Observable<ExperimentModel>,
+  ) {
+    // Only proceed if both value and unit are present
+    if (change.value === null || change.value === undefined ||
+      change.unit === null || change.unit === undefined) {
+      return;
+    }
+
+    const previousState = structuredClone(this.experimentModelService.experimentModel());
+    mutator(change.value, change.unit).subscribe({
+      error: (error) => this.handleUpdateError(error, previousState),
     });
   }
 
-  setWeight(row: ReactionInput, value: EnteredValue<WeightUnit>) {
-    this.experimentService.mutateModel({
-      type: 'SetInputWeight',
-      anchor: row.samples[0].anchor,
-      weight: value?.value,
-      unit: value?.unit,
+  private handleUpdateError(error: Error, previousState: ExperimentModel | null) {
+    console.error('Error updating data:', error);
+    if (previousState) {
+      console.log('Reverting to previous state due to error');
+      this.experimentModelService.setExperimentModel(previousState);
+    }
+    this.snackBar.open('There was an error', 'Close', { duration: 4000 });
+  }
+
+  addNewRow() {
+    if (!this.reaction()) {
+      this.snackBar.open('No reaction available', 'Close', { duration: 3000 });
+      return;
+    }
+
+    this.experimentModelService.updateDataModel({
+      type: 'AddEmptyInput',
+      anchor: this.reaction()!.anchor,
+    }).subscribe({
+      next: () => this.snackBar.open('Material added', 'Close', { duration: 2000 }),
+      error: (error) => {
+        const previousState = structuredClone(this.experimentModelService.experimentModel());
+        this.handleUpdateError(error, previousState);
+      },
     });
   }
 
-  setVolume(row: ReactionInput, value: EnteredValue<VolumeUnit>) {
-    this.experimentService.mutateModel({
-      type: 'SetInputVolume',
-      anchor: row.samples[0].anchor,
-      volume: value?.value,
-      unit: value?.unit,
-    });
-  }
-
-  setMol(row: ReactionInput, value: EnteredValue<MolUnit>) {
-    this.experimentService.mutateModel({
-      type: 'SetInputMol',
-      anchor: row.anchor,
-      mol: value?.value,
-      unit: value?.unit,
-    });
-  }
-
-  setEQ(row: ReactionInput, value: EnteredValue<NoUnit>) {
-    this.experimentService.mutateModel({
-      type: 'SetInputRowEQ',
-      anchor: row.anchor,
-      eq: value?.value,
-    });
-  }
-
-  setDensity(row: ReactionInput, value: EnteredValue<DensityUnit>) {
-    this.experimentService.mutateModel({
-      type: 'SetInputDensity',
-      anchor: row.samples[0].anchor,
-      density: value?.value,
-      unit: value?.unit,
-    });
-  }
-
-  setMolarity(row: ReactionInput, value: EnteredValue<MolarityUnit>) {
-    this.experimentService.mutateModel({
-      type: 'SetInputMolarity',
-      anchor: row.samples[0].anchor,
-      molarity: value?.value,
-      unit: value?.unit,
-    });
-  }
-
-  setPurity(row: ReactionInput, value: EnteredValue<NoUnit>) {
-    this.experimentService.mutateModel({
-      type: 'SetInputPurity',
-      anchor: row.samples[0].anchor,
-      purity: value?.value,
-    });
-  }
 }

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-products-table/reaction-products-table.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-products-table/reaction-products-table.component.ts
@@ -92,7 +92,7 @@ export class ReactionProductsTableComponent {
       id: 'hazardComments',
       header: 'Hazard Comments',
       type: 'text',
-      field: (row: ReactionOutput) => row.samples[0]?.healthHazard?.map(h => h.name).join(', ') // Data retrieved from External database
+      field: (row: ReactionOutput) => row.samples[0]?.healthHazards?.map(h => h.name).join(', ') // Data retrieved from External database
     },
     {
       id: 'eq',

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-scheme-view/reaction-scheme-view.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-scheme-view/reaction-scheme-view.component.ts
@@ -80,16 +80,11 @@ export class ReactionSchemeViewComponent {
       anchor: this.reaction.anchor
     };
 
-    const payload: MutateModelForm = {
-      model: this.experimentModelService.experimentModel(),
-      mutation: firstMutation,
-    };
-
     // Notify parent that update is starting
     this.modelUpdating.emit(true);
 
     this.experimentModelService
-      .updateDataModel(this.experimentId!, payload)
+      .updateDataModel(firstMutation)
       .subscribe({
         next: () => {
           // Notify parent that update completed

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-view/reaction-view.component.html
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-view/reaction-view.component.html
@@ -8,7 +8,10 @@
   </div>
   
   <div>
-    <eln-reaction-inputs-table [reaction]="reaction()" />
+    <eln-reaction-inputs-table
+      [reaction]="reaction()"
+      [experimentId]="experimentId()"
+    />
   </div>
 
   <div>

--- a/indigo-frontend/src/core/services/experiment/experiment-model.service.ts
+++ b/indigo-frontend/src/core/services/experiment/experiment-model.service.ts
@@ -2,7 +2,7 @@ import { inject, Injectable, signal } from '@angular/core';
 import { Observable, tap } from 'rxjs';
 import { ApiService } from '@/core/services/api.service';
 import { ExperimentModel } from '@/core/types/entities/experiments/experiment.i';
-import { MutateModelForm } from '@/core/types/entities/experiments/experiment-mutate-form.i';
+import { Mutation } from '@/core/types/entities/experiments/mutation.i';
 
 @Injectable({
   providedIn: 'root',
@@ -14,7 +14,7 @@ export class ExperimentModelService {
   readonly experimentModel = signal<ExperimentModel | null>(null);
   readonly isLoading = signal<boolean>(false);
   readonly hasError = signal<boolean>(false);
-  private readonly currentId = signal<string | null>(null);
+  readonly currentId = signal<string | null>(null);
 
   // Query methods
   load(experimentId: string) {
@@ -43,16 +43,37 @@ export class ExperimentModelService {
   }
 
   updateDataModel(
-    experimentId: string,
-    payload: MutateModelForm,
+    mutation: Mutation,
   ): Observable<ExperimentModel> {
+    const id = this.currentId();
+
+    if (!id) {
+      console.warn('No experiment ID in context');
+      return new Observable((observer) => {
+        observer.error(new Error('No experiment ID available'));
+      });
+    }
+
+    const model = this.experimentModel();
+    if (!model) {
+      console.warn('No experiment model available');
+      return new Observable((observer) => {
+        observer.error(new Error('No experiment model available'));
+      });
+    }
+
+    const payload = {
+      model,
+      mutation,
+    };
+
     this.isLoading.set(true);
     this.hasError.set(false);
 
     return this.service
       .request<ExperimentModel>(
         'post',
-        `experiments/${experimentId}/datamodel`,
+        `experiments/${id}/datamodel`,
         payload,
       )
       .pipe(

--- a/indigo-frontend/src/core/services/health-hazards/built-in-dictionary.service.ts
+++ b/indigo-frontend/src/core/services/health-hazards/built-in-dictionary.service.ts
@@ -1,0 +1,102 @@
+import { inject, Injectable, signal } from '@angular/core';
+import { Observable, tap } from 'rxjs';
+import { ApiService } from '@/core/services/api.service';
+import { DictionaryItemRef, BuiltInDictionary } from '@/core/types/entities/dictionary.i';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BuiltInDictionaryService {
+  private service = inject(ApiService);
+
+  // Signals for dictionary state - keyed by dictionary type
+  readonly dictionaries = signal<Map<BuiltInDictionary, DictionaryItemRef[]>>(new Map());
+  readonly isLoading = signal<Map<BuiltInDictionary, boolean>>(new Map());
+  readonly hasError = signal<Map<BuiltInDictionary, boolean>>(new Map());
+
+  // Query methods
+  load(dictionary: BuiltInDictionary) {
+    console.log(`BuiltInDictionaryService.load(${dictionary})`);
+    this.setLoading(dictionary, true);
+    this.setError(dictionary, false);
+
+    this.service
+      .request<DictionaryItemRef[]>('get', `dictionaries/${dictionary}`)
+      .subscribe({
+        next: (items) => {
+          this.setDictionary(dictionary, items);
+          this.setLoading(dictionary, false);
+        },
+        error: (error) => {
+          console.warn(
+            `Error loading dictionary ${dictionary}:`,
+            error,
+          );
+          this.setDictionary(dictionary, []);
+          this.setError(dictionary, true);
+          this.setLoading(dictionary, false);
+        },
+      });
+  }
+
+  // Getter methods
+  getDictionary(dictionary: BuiltInDictionary): Observable<DictionaryItemRef[]> {
+    // Return observable from the dictionary endpoint
+    return this.service
+      .request<DictionaryItemRef[]>('get', `dictionaries/${dictionary}`)
+      .pipe(
+        tap({
+          next: (items) => {
+            this.setDictionary(dictionary, items);
+            this.setLoading(dictionary, false);
+          },
+          error: (error) => {
+            console.error(`Error fetching dictionary ${dictionary}:`, error);
+            this.setError(dictionary, true);
+            this.setLoading(dictionary, false);
+          },
+        }),
+      );
+  }
+
+  getDictionaryItems(dictionary: BuiltInDictionary): DictionaryItemRef[] {
+    const dicts = this.dictionaries();
+    return dicts.get(dictionary) ?? [];
+  }
+
+  // Setter methods
+  setDictionary(dictionary: BuiltInDictionary, items: DictionaryItemRef[]) {
+    const dicts = this.dictionaries();
+    dicts.set(dictionary, items);
+    this.dictionaries.set(new Map(dicts));
+  }
+
+  setLoading(dictionary: BuiltInDictionary, value: boolean) {
+    const loadingMap = this.isLoading();
+    loadingMap.set(dictionary, value);
+    this.isLoading.set(new Map(loadingMap));
+  }
+
+  setError(dictionary: BuiltInDictionary, value: boolean) {
+    const errorMap = this.hasError();
+    errorMap.set(dictionary, value);
+    this.hasError.set(new Map(errorMap));
+  }
+
+  // Utility methods
+  refresh(dictionary: BuiltInDictionary) {
+    this.load(dictionary);
+  }
+
+  reset(dictionary: BuiltInDictionary) {
+    this.setDictionary(dictionary, []);
+    this.setLoading(dictionary, false);
+    this.setError(dictionary, false);
+  }
+
+  resetAll() {
+    this.dictionaries.set(new Map());
+    this.isLoading.set(new Map());
+    this.hasError.set(new Map());
+  }
+}

--- a/indigo-frontend/src/core/types/entities/compound.i.ts
+++ b/indigo-frontend/src/core/types/entities/compound.i.ts
@@ -2,6 +2,12 @@ import { SaltCodeRef } from '@core/types/entities/dictionary.i';
 import { EnteredValue } from '@core/types/entities/values.i';
 import { MolWeightUnit } from '@core/types/entities/experiments/experiment-shared.i';
 
+export enum CompoundType {
+  STORED = 'stored',
+  VIRTUAL = 'virtual',
+  UNKNOWN = 'unknown',
+}
+
 export interface CompoundRef {
   molFile: string | null;
   formula: string | null;
@@ -14,7 +20,7 @@ export interface CompoundRef {
 }
 
 export interface StoredCompoundRef extends CompoundRef {
-  type: 'stored';
+  type: CompoundType.STORED;
   compoundID: string;
   name: string | null;
   molWeight: EnteredValue<MolWeightUnit>;
@@ -23,7 +29,7 @@ export interface StoredCompoundRef extends CompoundRef {
 }
 
 export interface VirtualCompoundRef extends CompoundRef {
-  type: 'virtual';
+  type: CompoundType.VIRTUAL;
   compoundID: string;
   molFile: string;
   formula: string;
@@ -31,5 +37,5 @@ export interface VirtualCompoundRef extends CompoundRef {
 }
 
 export interface UnknownCompoundRef extends CompoundRef {
-  type: 'unknown';
+  type: CompoundType.UNKNOWN;
 }

--- a/indigo-frontend/src/core/types/entities/compound.i.ts
+++ b/indigo-frontend/src/core/types/entities/compound.i.ts
@@ -12,6 +12,8 @@ export interface CompoundRef {
   molFile: string | null;
   formula: string | null;
   name: string | null;
+  casNumber: string | null;
+  type: CompoundType;
   saltCode: SaltCodeRef | null;
   saltEQ: number | null;
   strCode: string | null;

--- a/indigo-frontend/src/core/types/entities/experiments/experiment.i.ts
+++ b/indigo-frontend/src/core/types/entities/experiments/experiment.i.ts
@@ -29,13 +29,14 @@ import { DictionaryItemRef } from '@core/types/entities/dictionary.i';
 // ================================
 export interface ReactionInputSample {
   anchor: UUID;
+  nbkBatchNumber?: string;
   chemicalName?: string;
   density?: EnteredValueDensityUnit;
   molarity?: EnteredValueMolarityUnit;
   volume?: EnteredValueVolumeUnit;
   purity: EnteredValueNoUnit;
   strCode?: STRCodeSample;
-  healthHazard: DictionaryItemRef[];
+  healthHazards: DictionaryItemRef[];
   row?: ReactionInput;
   sampleId?: UUID;
   mol?: EnteredValueMolUnit;
@@ -50,7 +51,7 @@ export interface ReactionOutputSample {
   molarity?: EnteredValueMolarityUnit;
   volume?: EnteredValueVolumeUnit;
   purity: EnteredValueNoUnit;
-  healthHazard: DictionaryItemRef[];
+  healthHazards: DictionaryItemRef[];
   row?: ReactionOutput;
   actualMol?: EnteredValueMolUnit;
   actualWeight?: EnteredValueWeightUnit;

--- a/indigo-frontend/src/core/types/entities/experiments/mutation.i.ts
+++ b/indigo-frontend/src/core/types/entities/experiments/mutation.i.ts
@@ -141,6 +141,11 @@ interface SetInputWeight extends ReactionInputSampleMutation {
   unit: WeightUnit | null;
 }
 
+interface SetInputComment extends ReactionInputSampleMutation {
+  type: 'SetInputComment';
+  comment: string | null;
+}
+
 interface ReactionOutputMutation extends BaseMutation {
   anchor: ReactionOutputAnchor;
 }
@@ -321,6 +326,7 @@ export type Mutation =
   | SetInputHealthHazards
   | SetInputMol
   | SetInputWeight
+  | SetInputComment
   // Output mutations
   | AddProductSample
   | SetOutputRowType


### PR DESCRIPTION
## Summary
Refactored reaction inputs table component with comprehensive data model mutations support and new health hazards dictionary service.

## Changes

- **Refactored `ExperimentModelService`**: Changed `updateDataModel()` to accept only `Mutation` parameter (instead of `experimentId` and `MutateModelForm`), implementing context-based state management using signals for experiment ID and model state tracking

- **Created `BuiltInDictionaryService`**: New service with Signal-based state management to handle dictionary data fetching, caching, and loading states for multiple dictionary types (health hazards, salt codes, etc.) with Map-based storage per dictionary type

- **Overhauled `ReactionInputsTableComponent`**: Complete rewrite from static row structure to dynamic sample-per-row model with configurable `ColumnConfig` interface, supporting 6 input types (text, number, select, checkbox, unit-input, multi-select) and real-time bidirectional data updates

- **Implemented inline table editing**: Added editable cells with validation, error handling, and automatic state rollback on API failures; integrated snackbar notifications for user feedback on mutations

- **Added row creation functionality**: Implemented "Add Material" button to dynamically add new inputs to reactions via `AddEmptyInput` mutation

- **Extended `Mutation` type system**: Added `SetInputComment` mutation type to support sample comment editing with anchor-based updates

- **Introduced `CompoundType` enum**: Refactored compound type literals to enum for type safety (`STORED`, `VIRTUAL`, `UNKNOWN`) with updates to all compound interface type definitions

- **Enhanced table HTML template**: Redesigned with Material controls (select, input, divider, icon), added multi-select hazard handling, and responsive inline editing with proper styling and field width customization

- **Updated `SampleSearchComponent`**: Simplified mutation creation to use new service API by removing `MutateModelForm` wrapper and passing mutations directly to `ExperimentModelService`

- **Improved health hazards display**: Integrated `BuiltInDictionaryService` for dynamic hazard loading and display with multi-select editing capability in the table

## Screenshot

<img width="1584" height="409" alt="image" src="https://github.com/user-attachments/assets/a3c01fa3-1512-496c-8475-446204f00ca3" />
