### PR TITLE
fix: change notebook description editing #389

### DIFF
--- a/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
@@ -48,7 +48,7 @@ export class NotebookEditComponent {
       },
     },
     {
-      type: 'input',
+      type: 'editor',
       key: 'description',
       props: {
         label: 'Description',
@@ -59,12 +59,12 @@ export class NotebookEditComponent {
 
   constructor(
     protected service: ApiService<Notebook>,
-    @Inject(MAT_DIALOG_DATA) private data: { notebook: NotebookDetail }
+    @Inject(MAT_DIALOG_DATA) private data: { notebook: NotebookDetail },
   ) {
     if (data?.notebook) {
       this.notebook = {
         name: data.notebook.name,
-        description: data.notebook.description
+        description: data.notebook.description,
       };
       this.notebookId = data.notebook.id;
     }
@@ -77,7 +77,9 @@ export class NotebookEditComponent {
       })
       .pipe(
         catchError((editError) => {
-          alert(`Error: ${editError?.error[0].message || 'There was an error updating notebook, please try again later.'}`);
+          alert(
+            `Error: ${editError?.error[0].message || 'There was an error updating notebook, please try again later.'}`,
+          );
           return of(null);
         }),
       )

--- a/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
@@ -1,13 +1,14 @@
 import { FormDialogComponent } from '@core/components/common/form-dialog/form-dialog.component';
 import { ApiService } from '@core/services/api.service';
 import { Notebook } from '@core/types/entities/notebook.i';
-import { NotebookDetail } from '@core/types/entities/notebook-detail.i';
+import { NotebookDialogData } from '@/core/types/entities/notebook-dialog-data.i';
 import { CommonModule } from '@angular/common';
 import { Component, Inject, inject } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
 import { FormlyFieldConfig } from '@ngx-formly/core';
+import { toHTML } from 'ngx-editor';
 import { catchError, of } from 'rxjs';
 import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
 
@@ -59,7 +60,7 @@ export class NotebookEditComponent {
 
   constructor(
     protected service: ApiService<Notebook>,
-    @Inject(MAT_DIALOG_DATA) private data: { notebook: NotebookDetail },
+    @Inject(MAT_DIALOG_DATA) private data: NotebookDialogData,
   ) {
     if (data?.notebook) {
       this.notebook = {
@@ -74,6 +75,10 @@ export class NotebookEditComponent {
     this.service
       .update(`notebooks/${this.notebookId}`, {
         ...data,
+        description:
+          typeof data.description === 'object'
+            ? toHTML(data.description)
+            : data.description,
       })
       .pipe(
         catchError((editError) => {

--- a/indigo-frontend/src/core/types/entities/notebook-dialog-data.i.ts
+++ b/indigo-frontend/src/core/types/entities/notebook-dialog-data.i.ts
@@ -1,0 +1,5 @@
+import { NotebookDetail } from './notebook-detail.i';
+
+export interface NotebookDialogData {
+  notebook: NotebookDetail;
+}


### PR DESCRIPTION
I changed notebook edit description according to mockup to be textarea with bold, italic and underline text effects. using ngx-editor which was already configured.
<img width="2301" height="1443" alt="image" src="https://github.com/user-attachments/assets/3ece1ff1-d442-4be4-aefd-312e0281ea66" />

