### PR TITLE
#Ng-387

### DIFF
--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
@@ -58,8 +58,8 @@ export class NotebookAddComponent {
       type: 'editor',
       key: 'description',
       props: {
-        label: 'Description',
-        placeholder: 'Description',
+        label: 'Notebook Description',
+        placeholder: 'Notebook Description',
       },
     },
   ];

--- a/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
@@ -64,7 +64,7 @@ export class ProjectAddComponent implements OnInit {
       key: 'description',
       defaultValue: '',
       props: {
-        label: 'Description',
+        label: 'Project Description',
         placeholder: 'Description',
       },
     },

--- a/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
@@ -65,7 +65,7 @@ export class ProjectAddComponent implements OnInit {
       defaultValue: '',
       props: {
         label: 'Project Description',
-        placeholder: 'Description',
+        placeholder: 'Project Description',
       },
     },
   ];


### PR DESCRIPTION
Here, you can see the updated label texts for both 'Add Project' and 'Add Notebook' modals: https://github.com/orgs/epam/projects/41/views/1?pane=issue&itemId=142822859&issue=epam%7CIndigo-ELN-v.-2.0%7C387.

You can also see the changes regarding the placeholer texts of description textareas. There is nothing mentioned about them in the 'Actual result' part, there is only the design screenshot, but on the designs we only see the active state of the textarea. I decide to change it anyway with the copy of the text which those appropriate labels include, I think it matches better to the entire form organization. But I asked Daria (designer) about that fact, how they should be displayed, and if she will provide the different direction, then I am going to follow it.