### PR TITLE
feat(410): [FE] Implement Product Batch Summary component

### DIFF
--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/editable-data-table/editable-data-table.component.html
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/editable-data-table/editable-data-table.component.html
@@ -1,0 +1,103 @@
+<div class="flex justify-between py-1">
+  <h3 class="text-sm font-semibold p-3">{{ title() }}</h3>
+  @if (showAddButton()) {
+  <div class="flex justify-between items-center">
+    <eln-button (click)="onAddRow()" variant="grey">
+      <mat-icon class="text-md">add</mat-icon>
+    </eln-button>
+  </div>
+  }
+</div>
+<div class="w-full overflow-x-auto border border-gray-300 rounded">
+  <table mat-table [dataSource]="dataSource()" class="w-full" style="background-color: white;">
+    @for (column of columns(); track column.id) {
+    <ng-container [matColumnDef]="column.id">
+      <th mat-header-cell *matHeaderCellDef
+        class="text-left !font-bold text-xs text-gray-900 p-1 border-b border-r !border-gray-200 last:border-r-0 min-w-32 overflow-hidden text-ellipsis whitespace-nowrap">
+        {{ column.header }}
+      </th>
+      <td mat-cell *matCellDef="let row"
+        class="text-xs p-0 border-b border-r !border-gray-200 min-w-32 overflow-visible" style="color: #3F50B5;">
+
+        <!-- Text Input -->
+        <input *ngIf="column.type === ColumnInputType.TEXT" type="text" placeholder="—" matInput style="outline: none;"
+          [value]="column.field(row) || ''" [disabled]="!(column.editable?.(row) ?? true)"
+          (blur)="column.onSave?.(row, $event)" (keydown.enter)="column.onSave?.(row, $event)" />
+
+        <!-- Number Input -->
+        <input *ngIf="column.type === ColumnInputType.NUMBER" type="number" placeholder="—" style="outline: none;"
+          [value]="column.field(row) || ''" [disabled]="!(column.editable?.(row) ?? true)"
+          (blur)="column.onSave?.(row, $event)" (keydown.enter)="column.onSave?.(row, $event)" />
+
+        <!-- Select -->
+        <mat-select *ngIf="column.type === ColumnInputType.SELECT" hideSingleSelectionIndicator
+          class="!w-full !h-full !text-xs capitalize" [value]="column.field(row)"
+          [disabled]="!(column.editable?.(row) ?? true)" (selectionChange)="column.onSave?.(row, $event.value)">
+          @for (option of column.options; track option.id) {
+          <mat-option [value]="option.id" style="font-size: 0.8rem" class="capitalize">{{ option.name }}</mat-option>
+          }
+        </mat-select>
+
+        <!-- Checkbox -->
+        <input *ngIf="column.type === ColumnInputType.CHECKBOX" type="checkbox" [checked]="column.field(row)"
+          [disabled]="!(column.editable?.(row) ?? true)" (change)="column.onSave?.(row, $event)" />
+
+        <!-- Unit Input (weight, volume, etc) -->
+        <div *ngIf="column.type === ColumnInputType.UNIT_INPUT" class="flex w-full h-full">
+          @let unitField = toUnitField(column.field(row));
+          <input #valueInput type="number" matInput placeholder="—" style="outline: none;"
+            [value]="unitField?.value ?? ''" [disabled]="!(column.editable?.(row) ?? true)"
+            (blur)="column.onSave?.(row, { value: $any($event.target).valueAsNumber, unit: unitField?.unit })"
+            (keydown.enter)="column.onSave?.(row, { value: $any($event.target).valueAsNumber, unit: unitField?.unit })" />
+          <mat-divider vertical style="opacity: 0.3;" />
+          <mat-select class="!h-full !text-xs" hideSingleSelectionIndicator style="min-width: 4rem; text-align: center;"
+            [value]="unitField?.unit" [disabled]="!(column.editable?.(row) ?? true)"
+            (selectionChange)="column.onSave?.(row, { value: valueInput.valueAsNumber, unit: $event.value })">
+            @for (unit of column.options; track unit.id) {
+            <mat-option [value]="unit.id" style="font-size: 0.8rem;">{{ unit.name }}</mat-option>
+            }
+          </mat-select>
+        </div>
+
+        <!-- Multi-Select -->
+        <mat-select #multiSelect *ngIf="column.type === ColumnInputType.MULTI_SELECT" multiple
+          hideSingleSelectionIndicator class="!w-full !h-full !text-xs capitalize" [value]="column.field(row)"
+          [compareWith]="compareDictionaryItems" [disabled]="!(column.editable?.(row) ?? true)"
+          (openedChange)="!$event && column.onSave?.(row, multiSelect.value)">
+          <mat-select-trigger>
+            <div class="flex items-center gap-1 min-h-6 overflow-x-auto no-scrollbar pr-4">
+              @for (hazard of multiSelect.value; track hazard.id) {
+              <span
+                class="px-1.5 py-0.5 rounded-full bg-primary-50 text-primary-700 border border-primary-200 text-[0.65rem] whitespace-nowrap">
+                {{ hazard.name }}
+              </span>
+              }
+            </div>
+          </mat-select-trigger>
+          @for (option of column.options; track option.id) {
+          <mat-option [value]="option" style="font-size: 0.8rem" class="capitalize">{{ option.name }}</mat-option>
+          }
+        </mat-select>
+
+        <!-- Button -->
+        <div *ngIf="column.type === ColumnInputType.BUTTON" class="p-2">
+          <button
+            class="px-3 py-1 text-xs font-medium text-primary-700 bg-primary-50 border border-primary-200 rounded hover:bg-primary-100 transition-colors"
+            (click)="column.onSave?.(row)">
+            {{ column.field(row) }}
+          </button>
+        </div>
+      </td>
+    </ng-container>
+    }
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns()" class="h-8 bg-white"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns()" class="h-10 bg-white hover:!bg-gray-50"></tr>
+  </table>
+
+  @if (dataSource().length === 0) {
+  <div class="flex flex-col items-center justify-center py-12 text-gray-600 border-t border-gray-300">
+    <div class="text-sm">{{ emptyMessage() }}</div>
+  </div>
+  }
+</div>

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/editable-data-table/editable-data-table.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/editable-data-table/editable-data-table.component.ts
@@ -1,0 +1,83 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  MatCell,
+  MatCellDef,
+  MatColumnDef,
+  MatHeaderCell,
+  MatHeaderCellDef,
+  MatHeaderRow,
+  MatHeaderRowDef,
+  MatRow,
+  MatRowDef,
+  MatTable,
+} from '@angular/material/table';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelect, MatOption, MatSelectTrigger } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
+import { MatDivider } from '@angular/material/divider';
+import { FormsModule } from '@angular/forms';
+import { ButtonComponent } from '@core/components/common/button/button.component';
+import { DictionaryItemRef } from '@core/types/entities/dictionary.i';
+import {
+  ColumnInputType,
+  ColumnConfig,
+  FieldValue,
+  UnitFieldValue,
+} from '../shared/editable-table.types';
+
+@Component({
+  selector: 'eln-editable-data-table',
+  templateUrl: './editable-data-table.component.html',
+  imports: [
+    MatTable,
+    MatColumnDef,
+    MatHeaderCell,
+    MatHeaderCellDef,
+    MatCell,
+    MatCellDef,
+    MatHeaderRow,
+    MatHeaderRowDef,
+    MatRow,
+    MatRowDef,
+    MatIconModule,
+    MatSelect,
+    MatSelectTrigger,
+    MatOption,
+    MatInput,
+    MatDivider,
+    FormsModule,
+    CommonModule,
+    ButtonComponent,
+  ],
+})
+export class EditableDataTableComponent<TRow = unknown> {
+  readonly ColumnInputType = ColumnInputType;
+
+  title = input.required<string>();
+  dataSource = input.required<TRow[]>();
+  columns = input.required<ColumnConfig<TRow>[]>();
+  displayedColumns = input.required<string[]>();
+  emptyMessage = input<string>('No data available');
+  showAddButton = input<boolean>(true);
+
+  addRow = output<void>();
+
+  compareDictionaryItems = (a?: DictionaryItemRef | null, b?: DictionaryItemRef | null) =>
+    !!a && !!b ? a.id === b.id : a === b;
+
+  getInputType(columnId: string): ColumnInputType {
+    const column = this.columns().find(c => c.id === columnId);
+    return column?.type ?? ColumnInputType.TEXT;
+  }
+
+  toUnitField(fieldValue: FieldValue): UnitFieldValue | null {
+    return fieldValue && typeof fieldValue !== 'string' && typeof fieldValue !== 'boolean' && !Array.isArray(fieldValue)
+      ? fieldValue
+      : null;
+  }
+
+  onAddRow() {
+    this.addRow.emit();
+  }
+}

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/product-batch-summary-table/product-batch-summary-table.component.html
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/product-batch-summary-table/product-batch-summary-table.component.html
@@ -1,9 +1,9 @@
 <eln-editable-data-table
-  title="Reactants, Reagents, Solvents"
+  title="Product Batch Summary"
   [dataSource]="dataSource()"
   [columns]="columns()"
   [displayedColumns]="displayedColumns()"
-  emptyMessage="No material added"
+  emptyMessage="No batches added"
   [showAddButton]="true"
   (addRow)="addNewRow()"
 />

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/product-batch-summary-table/product-batch-summary-table.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/product-batch-summary-table/product-batch-summary-table.component.ts
@@ -1,0 +1,295 @@
+import { Component, computed, inject, input } from '@angular/core';
+import { Observable } from 'rxjs';
+import {
+  Reaction,
+  ReactionOutput,
+  ReactionOutputSample,
+  ExperimentModel,
+} from '@core/types/entities/experiments/experiment.i';
+import {
+  VolumeUnit,
+  WeightUnit,
+  MolWeightUnit,
+  MolUnit,
+  ReactionOutputType,
+  SampleRegistrationStatus,
+} from '@core/types/entities/experiments/experiment-shared.i';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { ExperimentModelService } from '@core/services/experiment/experiment-model.service';
+import { EditableDataTableComponent } from '../editable-data-table/editable-data-table.component';
+import {
+  ColumnInputType,
+  ColumnConfig,
+  UnitInputChange,
+  ColumnOption,
+} from '../shared/editable-table.types';
+
+interface OutputSampleRow {
+  output: ReactionOutput;
+  sample: ReactionOutputSample;
+}
+
+@Component({
+  selector: 'eln-product-batch-summary-table',
+  templateUrl: './product-batch-summary-table.component.html',
+  imports: [
+    MatSnackBarModule,
+    EditableDataTableComponent,
+  ],
+})
+export class ProductBatchSummaryTableComponent {
+  private experimentModelService = inject(ExperimentModelService);
+  private snackBar = inject(MatSnackBar);
+
+  reaction = input<Reaction | null>(null);
+  experimentId = input<string | null>(null);
+
+  // TODO: Remove mock data once backend provides real output samples
+  private mockOutputSamples = computed<OutputSampleRow[]>(() => {
+    // Create mock samples for demonstration (independent of real data)
+    const mockOutput1 = {
+      anchor: 'mock-output-1',
+      chemicalName: 'P1',
+      compound: {
+        strCode: 'P1',
+        formula: 'C10H12O2',
+        molWeight: { value: 164.2, unit: MolWeightUnit.G_PER_MOL },
+      },
+      type: ReactionOutputType.INTERMEDIATE,
+      eq: { value: 1 },
+      samples: [],
+    } as ReactionOutput;
+
+    const mockOutput2 = {
+      anchor: 'mock-output-2',
+      chemicalName: 'P2',
+      compound: {
+        strCode: 'P2',
+        formula: 'C8H10O',
+        molWeight: { value: 122.16, unit: MolWeightUnit.G_PER_MOL },
+      },
+      type: ReactionOutputType.BY_PRODUCT,
+      eq: { value: 1 },
+      samples: [],
+    } as ReactionOutput;
+
+    return [
+      {
+        output: mockOutput1,
+        sample: {
+          anchor: 'mock-sample-1',
+          nbkBatchNumber: '001',
+          actualWeight: { value: 2.46, unit: WeightUnit.MG },
+          volume: undefined,
+          actualMol: undefined,
+          yield: { value: 0.01 },
+          purity: { value: 0.04 },
+          registrationStatus: undefined,
+          healthHazards: [],
+          handlingPrecautions: [],
+          storageInstructions: [],
+          compoundProtection: [],
+          solubilityInSolvents: [],
+          residualSolvents: [],
+          purityCalculations: [],
+          precursorReactantIds: [],
+        } as ReactionOutputSample,
+      },
+      {
+        output: mockOutput2,
+        sample: {
+          anchor: 'mock-sample-2',
+          nbkBatchNumber: '002',
+          actualWeight: { value: 2.46, unit: WeightUnit.MG },
+          volume: undefined,
+          actualMol: undefined,
+          yield: { value: 0.01 },
+          purity: { value: 0.04 },
+          registrationStatus: undefined,
+          healthHazards: [],
+          handlingPrecautions: [],
+          storageInstructions: [],
+          compoundProtection: [],
+          solubilityInSolvents: [],
+          residualSolvents: [],
+          purityCalculations: [],
+          precursorReactantIds: [],
+        } as ReactionOutputSample,
+      },
+    ];
+  });
+
+  dataSource = computed(() => {
+    // TODO: Replace mock data with real data from reaction outputs
+    const mockData = this.mockOutputSamples();
+    if (mockData.length > 0) {
+      return mockData;
+    }
+
+    // Fallback to real data when available
+    const outputs = this.reaction()?.outputs ?? [];
+    return outputs.flatMap(output =>
+      output.samples.map(sample => ({ output, sample }))
+    );
+  });
+
+  readonly columns = computed<ColumnConfig<OutputSampleRow>[]>(() => [
+    {
+      id: 'batchId',
+      header: 'Batch ID',
+      type: ColumnInputType.TEXT,
+      field: (row: OutputSampleRow) => row.sample.nbkBatchNumber ?? null,
+      editable: () => false,
+    },
+    {
+      id: 'chemicalName',
+      header: 'Chemical Name',
+      type: ColumnInputType.TEXT,
+      field: (row: OutputSampleRow) => row.output.chemicalName ?? null,
+      editable: () => false,
+    },
+    {
+      id: 'reactionRole',
+      header: 'Reaction Role',
+      type: ColumnInputType.TEXT,
+      field: (row: OutputSampleRow) => this.formatReactionOutputType(row.output.type),
+      editable: () => false,
+    },
+    {
+      id: 'regStatus',
+      header: 'Reg Status',
+      type: ColumnInputType.TEXT,
+      field: (row: OutputSampleRow) => this.formatRegistrationStatus(row.sample.registrationStatus),
+      editable: () => false,
+    },
+    {
+      id: 'totalWeight',
+      header: 'Total Weight',
+      type: ColumnInputType.UNIT_INPUT,
+      field: (row: OutputSampleRow) =>
+        row.sample.actualWeight?.value
+          ? { value: row.sample.actualWeight.value, unit: row.sample.actualWeight.unit }
+          : null,
+      onSave: (row: OutputSampleRow) => {
+        // TODO: Implement mutation for setting output sample actual weight
+        console.log('TODO: Set output actual weight', row.sample.anchor);
+        this.snackBar.open('Weight update not yet implemented', 'Close', { duration: 3000 });
+      },
+      options: Object.values(WeightUnit).map(unit => ({ id: unit, name: unit })) as ColumnOption[],
+    },
+    {
+      id: 'totalVolume',
+      header: 'Total Volume',
+      type: ColumnInputType.UNIT_INPUT,
+      field: (row: OutputSampleRow) =>
+        row.sample.volume?.value
+          ? { value: row.sample.volume.value, unit: row.sample.volume.unit }
+          : null,
+      onSave: (row: OutputSampleRow) => {
+        // TODO: Implement mutation for setting output sample volume
+        console.log('TODO: Set output volume', row.sample.anchor);
+        this.snackBar.open('Volume update not yet implemented', 'Close', { duration: 3000 });
+      },
+      options: Object.values(VolumeUnit).map(unit => ({ id: unit, name: unit })) as ColumnOption[],
+    },
+    {
+      id: 'totalMoles',
+      header: 'Total Moles',
+      type: ColumnInputType.UNIT_INPUT,
+      field: (row: OutputSampleRow) =>
+        row.sample.actualMol?.value
+          ? { value: row.sample.actualMol.value, unit: row.sample.actualMol.unit }
+          : null,
+      onSave: (row: OutputSampleRow) => {
+        // TODO: Implement mutation for setting output sample moles
+        console.log('TODO: Set output moles', row.sample.anchor);
+        this.snackBar.open('Moles update not yet implemented', 'Close', { duration: 3000 });
+      },
+      options: Object.values(MolUnit).map(unit => ({ id: unit, name: unit })) as ColumnOption[],
+    },
+    {
+      id: 'yield',
+      header: 'Yield',
+      type: ColumnInputType.NUMBER,
+      field: (row: OutputSampleRow) => row.sample.yield?.value?.toString() ?? null,
+      editable: () => false,
+    },
+    {
+      id: 'purity',
+      header: 'Purity',
+      type: ColumnInputType.NUMBER,
+      field: (row: OutputSampleRow) => row.sample.purity?.value?.toString() ?? null,
+      onSave: (row: OutputSampleRow, event: Event) => {
+        // TODO: Implement mutation for setting output sample purity
+        const value = +(event.target as HTMLInputElement).value;
+        console.log('TODO: Set output purity', row.sample.anchor, value);
+        
+        // Placeholder for now
+        this.snackBar.open('Purity update not yet implemented', 'Close', { duration: 3000 });
+      },
+    },
+    {
+      id: 'syncWithProducts',
+      header: 'Sync with Products',
+      type: ColumnInputType.BUTTON,
+      field: () => '🔄',
+      onSave: (row: OutputSampleRow) => {
+        // TODO: Implement sync with products functionality
+        console.log('TODO: Sync with products', row.sample.anchor);
+        this.snackBar.open('Sync functionality not yet implemented', 'Close', { duration: 3000 });
+      },
+    },
+  ]);
+
+  displayedColumns = computed(() => this.columns().map((col) => col.id));
+
+  private formatReactionOutputType(type: ReactionOutputType): string {
+    const typeMap: Record<ReactionOutputType, string> = {
+      [ReactionOutputType.FINAL]: 'Final',
+      [ReactionOutputType.BY_PRODUCT]: 'By Product',
+      [ReactionOutputType.INTERMEDIATE]: 'Intermediate',
+    };
+    return typeMap[type] ?? type;
+  }
+
+  private formatRegistrationStatus(status?: SampleRegistrationStatus): string {
+    if (!status) return 'None';
+    
+    const statusMap: Record<SampleRegistrationStatus, string> = {
+      [SampleRegistrationStatus.IN_PROGRESS]: 'In Progress',
+      [SampleRegistrationStatus.FAILED]: 'Failed',
+      [SampleRegistrationStatus.REGISTERED]: 'Registered',
+    };
+    return statusMap[status] ?? status;
+  }
+
+  private applyUnitInputChange(
+    change: UnitInputChange,
+    mutator: (value: number | undefined, unit: string | undefined) => Observable<ExperimentModel>,
+  ) {
+    // Only proceed if both value and unit are present
+    if (change.value === null || change.value === undefined ||
+      change.unit === null || change.unit === undefined) {
+      return;
+    }
+
+    const previousState = structuredClone(this.experimentModelService.experimentModel());
+    mutator(change.value, change.unit).subscribe({
+      error: (error) => this.handleUpdateError(error, previousState),
+    });
+  }
+
+  private handleUpdateError(error: Error, previousState: ExperimentModel | null) {
+    console.error('Error updating data:', error);
+    if (previousState) {
+      console.log('Reverting to previous state due to error');
+      this.experimentModelService.setExperimentModel(previousState);
+    }
+    this.snackBar.open('There was an error', 'Close', { duration: 4000 });
+  }
+
+  addNewRow() {
+    // TODO: Implement mutation for adding new output sample row
+    this.snackBar.open('Add row functionality not yet implemented', 'Close', { duration: 3000 });
+  }
+}

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-inputs-table/reaction-inputs-table.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-inputs-table/reaction-inputs-table.component.ts
@@ -1,5 +1,4 @@
 import { Component, computed, inject, input, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
 import {
   Reaction,
@@ -16,99 +15,35 @@ import {
   WeightUnit,
 } from '@core/types/entities/experiments/experiment-shared.i';
 import { DictionaryItemRef, BuiltInDictionary } from '@core/types/entities/dictionary.i';
-import {
-  MatCell,
-  MatCellDef,
-  MatColumnDef,
-  MatHeaderCell,
-  MatHeaderCellDef,
-  MatHeaderRow,
-  MatHeaderRowDef,
-  MatRow,
-  MatRowDef,
-  MatTable,
-} from '@angular/material/table';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatIconModule } from '@angular/material/icon';
-import { MatSelect, MatOption, MatSelectTrigger } from '@angular/material/select';
-import { MatInput } from '@angular/material/input';
-import { MatDivider } from '@angular/material/divider';
-import { FormsModule } from '@angular/forms';
 import { ExperimentModelService } from '@core/services/experiment/experiment-model.service';
 import { BuiltInDictionaryService } from '@core/services/health-hazards/built-in-dictionary.service';
-import { ButtonComponent } from '@core/components/common/button/button.component';
 import { CompoundType } from '@/core/types/entities/compound.i';
-
-enum ColumnInputType {
-  TEXT = 'text',
-  NUMBER = 'number',
-  SELECT = 'select',
-  CHECKBOX = 'checkbox',
-  UNIT_INPUT = 'unit-input',
-  MULTI_SELECT = 'multi-select',
-}
+import { EditableDataTableComponent } from '../editable-data-table/editable-data-table.component';
+import {
+  ColumnInputType,
+  ColumnConfig,
+  UnitInputChange,
+  ColumnOption,
+} from '../shared/editable-table.types';
 
 interface InputSampleRow {
   input: ReactionInput;
   sample: ReactionInputSample;
 }
 
-interface UnitFieldValue { value: number | string; unit: string; }
-
-type FieldValue = string | null | boolean | UnitFieldValue | DictionaryItemRef[];
-
-interface UnitInputChange {
-  value?: number | null;
-  unit?: string | null;
-}
-
-interface ColumnOption {
-  id: string;
-  name: string;
-}
-
-interface ColumnConfig {
-  id: string;
-  header: string;
-  type: ColumnInputType;
-  field: (row: InputSampleRow) => FieldValue;
-  editable?: (row: InputSampleRow) => boolean;
-  onSave?: (row: InputSampleRow, payload?: unknown) => void;
-  options?: ColumnOption[] | DictionaryItemRef[]; // For select and multi-select columns
-}
-
 @Component({
   selector: 'eln-reaction-inputs-table',
   templateUrl: './reaction-inputs-table.component.html',
   imports: [
-    MatTable,
-    MatColumnDef,
-    MatHeaderCell,
-    MatHeaderCellDef,
-    MatCell,
-    MatCellDef,
-    MatHeaderRow,
-    MatHeaderRowDef,
-    MatRow,
-    MatRowDef,
     MatSnackBarModule,
-    MatIconModule,
-    MatSelect,
-    MatSelectTrigger,
-    MatOption,
-    MatInput,
-    MatDivider,
-    FormsModule,
-    CommonModule,
-    ButtonComponent,
+    EditableDataTableComponent,
   ],
 })
 export class ReactionInputsTableComponent implements OnInit {
   private experimentModelService = inject(ExperimentModelService);
   private builtInDictionaryService = inject(BuiltInDictionaryService);
   private snackBar = inject(MatSnackBar);
-
-  readonly ColumnInputType = ColumnInputType;
 
   reaction = input<Reaction | null>(null);
   experimentId = input<string | null>(null);
@@ -130,7 +65,7 @@ export class ReactionInputsTableComponent implements OnInit {
     this.builtInDictionaryService.load(BuiltInDictionary.HEALTH_HAZARD);
   }
 
-  readonly columns = computed<ColumnConfig[]>(() => [
+  readonly columns = computed<ColumnConfig<InputSampleRow>[]>(() => [
     {
       id: 'compoundId',
       header: 'Compound ID',
@@ -436,15 +371,6 @@ export class ReactionInputsTableComponent implements OnInit {
 
   compareDictionaryItems = (a?: DictionaryItemRef | null, b?: DictionaryItemRef | null) =>
     !!a && !!b ? a.id === b.id : a === b;
-
-  getInputType(columnId: string): ColumnInputType {
-    const column = this.columns().find(c => c.id === columnId);
-    return column?.type ?? ColumnInputType.TEXT;
-  }
-
-  toUnitField(fieldValue: FieldValue): UnitFieldValue | null {
-    return fieldValue && typeof fieldValue !== 'string' && typeof fieldValue !== 'boolean' && !Array.isArray(fieldValue) ? fieldValue : null;
-  }
 
   private applyUnitInputChange(
     change: UnitInputChange,

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-view/reaction-view.component.html
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-view/reaction-view.component.html
@@ -17,4 +17,11 @@
   <div>
     <eln-reaction-products-table [reaction]="reaction()" />
   </div>
+
+  <div>
+    <eln-product-batch-summary-table
+      [reaction]="reaction()"
+      [experimentId]="experimentId()"
+    />
+  </div>
 </div>

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-view/reaction-view.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/reaction-view/reaction-view.component.ts
@@ -2,6 +2,7 @@ import { Component, input, output, inject, computed, effect } from '@angular/cor
 import { CommonModule } from '@angular/common';
 import { ReactionInputsTableComponent } from '../reaction-inputs-table/reaction-inputs-table.component';
 import { ReactionProductsTableComponent } from '../reaction-products-table/reaction-products-table.component';
+import { ProductBatchSummaryTableComponent } from '../product-batch-summary-table/product-batch-summary-table.component';
 import { ExperimentModelService } from '@core/services/experiment/experiment-model.service';
 import {
   ReactionSchemeViewComponent
@@ -14,7 +15,8 @@ import {
     CommonModule,
     ReactionSchemeViewComponent,
     ReactionInputsTableComponent,
-    ReactionProductsTableComponent
+    ReactionProductsTableComponent,
+    ProductBatchSummaryTableComponent
   ],
   providers: [ExperimentModelService],
   templateUrl: './reaction-view.component.html',

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/shared/editable-table.types.ts
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/shared/editable-table.types.ts
@@ -1,0 +1,38 @@
+import { DictionaryItemRef } from '@core/types/entities/dictionary.i';
+
+export enum ColumnInputType {
+  TEXT = 'text',
+  NUMBER = 'number',
+  SELECT = 'select',
+  CHECKBOX = 'checkbox',
+  UNIT_INPUT = 'unit-input',
+  MULTI_SELECT = 'multi-select',
+  BUTTON = 'button',
+}
+
+export interface UnitFieldValue {
+  value: number | string;
+  unit: string;
+}
+
+export type FieldValue = string | null | boolean | UnitFieldValue | DictionaryItemRef[];
+
+export interface UnitInputChange {
+  value?: number | null;
+  unit?: string | null;
+}
+
+export interface ColumnOption {
+  id: string;
+  name: string;
+}
+
+export interface ColumnConfig<TRow = unknown> {
+  id: string;
+  header: string;
+  type: ColumnInputType;
+  field: (row: TRow) => FieldValue;
+  editable?: (row: TRow) => boolean;
+  onSave?: (row: TRow, payload?: unknown) => void;
+  options?: ColumnOption[] | DictionaryItemRef[];
+}


### PR DESCRIPTION
- New Product Batch Summary component
- No mutations included in the scope of this PR (only foundational table)
- Added shared `eln-editable-data-table` component for product batch summary component and reaction inputs table component

<img width="3423" height="1281" alt="image" src="https://github.com/user-attachments/assets/8d0175f0-c74d-4ff9-abf2-0c006aacb89c" />
