### PR TITLE
 feat: add checkbox #353

### DIFF
--- a/indigo-frontend/src/app/app.component.html
+++ b/indigo-frontend/src/app/app.component.html
@@ -14,6 +14,20 @@
   >
     <router-outlet />
   </ng-template>
+  <ng-template amplifySlot="sign-in-footer">
+    <div class="flex items-center gap-2 px-4 pb-4">
+      <input
+        id="rememberMe"
+        type="checkbox"
+        [checked]="isRemembered"
+        (change)="onRememberMeChange($event)"
+        class="w-4 h-4 text-indigo-600 border-gray-300 rounded cursor-pointer"
+      />
+      <label for="rememberMe" class="text-sm text-neutral-700 cursor-pointer">
+        Remember me
+      </label>
+    </div>
+  </ng-template>
   <ng-template amplifySlot="sign-in-header">
     <h3
       class="amplify-heading m-4! mb-0! pb-4! text-[1.125rem] font-medium! border-b! border-neutral-300!"

--- a/indigo-frontend/src/app/app.component.html
+++ b/indigo-frontend/src/app/app.component.html
@@ -1,5 +1,4 @@
 <amplify-authenticator [hideSignUp]="true">
-  <div class="Body"></div>
   <ng-template amplifySlot="header">
     <div
       class="mx-auto h-full"

--- a/indigo-frontend/src/app/app.component.html
+++ b/indigo-frontend/src/app/app.component.html
@@ -1,4 +1,5 @@
 <amplify-authenticator [hideSignUp]="true">
+  <div class="Body"></div>
   <ng-template amplifySlot="header">
     <div
       class="mx-auto h-full"
@@ -15,7 +16,7 @@
     <router-outlet />
   </ng-template>
   <ng-template amplifySlot="sign-in-footer">
-    <div class="flex items-center gap-2 px-4 pb-4">
+    <div class="flex items-center gap-2 px-4 pb-4" id="rememberme">
       <input
         id="rememberMe"
         type="checkbox"

--- a/indigo-frontend/src/app/app.component.scss
+++ b/indigo-frontend/src/app/app.component.scss
@@ -51,5 +51,4 @@
   bottom: 62px;
   margin-left: 3px;
   accent-color: var(--primary-500);
-  // margin-bottom: 20px;
 }

--- a/indigo-frontend/src/app/app.component.scss
+++ b/indigo-frontend/src/app/app.component.scss
@@ -14,6 +14,7 @@
 
     [data-amplify-router] {
       border-radius: 14px;
+      position: relative;
     }
     [data-amplify-footer] {
       display: none;
@@ -26,7 +27,7 @@
     [amplify-button] {
       &.amplify-button--primary {
         border-radius: 8px;
-        margin-top: 28px;
+        margin-top: 38px;
         position: relative;
         &::after {
           width: 100%;
@@ -44,4 +45,10 @@
       border-right: 0;
     }
   }
+}
+#rememberme {
+  position: absolute;
+  bottom: 60px;
+  margin-left: 3px;
+  // margin-bottom: 20px;
 }

--- a/indigo-frontend/src/app/app.component.scss
+++ b/indigo-frontend/src/app/app.component.scss
@@ -27,7 +27,7 @@
     [amplify-button] {
       &.amplify-button--primary {
         border-radius: 8px;
-        margin-top: 38px;
+        margin-top: 42px;
         position: relative;
         &::after {
           width: 100%;
@@ -48,7 +48,8 @@
 }
 #rememberme {
   position: absolute;
-  bottom: 60px;
+  bottom: 62px;
   margin-left: 3px;
+  accent-color: var(--primary-500);
   // margin-bottom: 20px;
 }

--- a/indigo-frontend/src/app/app.component.ts
+++ b/indigo-frontend/src/app/app.component.ts
@@ -1,6 +1,8 @@
-import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
+import { sessionStorage, defaultStorage } from 'aws-amplify/utils';
+import { cognitoUserPoolsTokenProvider } from 'aws-amplify/auth/cognito';
+import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'eln-root',
   imports: [RouterOutlet, AmplifyAuthenticatorModule],
@@ -8,6 +10,29 @@ import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
   styleUrls: ['./app.component.scss'],
   standalone: true,
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'indigo-frontend';
+  isRemembered = false;
+  ngOnInit() {
+    const hasLocalStorage = Object.keys(localStorage).some((key) =>
+      key.startsWith('CognitoIdentityServiceProvider'),
+    );
+
+    if (hasLocalStorage) {
+      this.isRemembered = true;
+      cognitoUserPoolsTokenProvider.setKeyValueStorage(defaultStorage);
+    } else {
+      this.isRemembered = false;
+      cognitoUserPoolsTokenProvider.setKeyValueStorage(sessionStorage);
+    }
+  }
+  onRememberMeChange(event: any) {
+    const isChecked = (event.target as HTMLInputElement).checked;
+    this.isRemembered = isChecked;
+    if (isChecked) {
+      cognitoUserPoolsTokenProvider.setKeyValueStorage(defaultStorage);
+    } else {
+      cognitoUserPoolsTokenProvider.setKeyValueStorage(sessionStorage);
+    }
+  }
 }

--- a/indigo-frontend/src/main.ts
+++ b/indigo-frontend/src/main.ts
@@ -28,7 +28,7 @@ Amplify.configure({
 });
 
 I18n.putVocabulariesForLanguage('en', {
-  'Sign in': 'Log in'
+  'Sign in': 'Log in',
 });
 
 I18n.setLanguage('en');


### PR DESCRIPTION
its working like this (if we check 'remember me' it becomes localstorage data, after closing tab and opening again , it logins automatically and if we don't check 'remember me' it becomes session storage so if we close tab an reopen it will show login page) so I used Amplify`s Cognito, but a problem is a Placement of checkbox , I tried a lot, but could not reach desired position without braking stuff


current situation:
<img width="1582" height="1193" alt="image" src="https://github.com/user-attachments/assets/2400b9a8-6559-459b-8a8e-a59ef316d694" />



CHANGED
its working and according to Figma template
<img width="2508" height="1600" alt="image" src="https://github.com/user-attachments/assets/f8898be0-edc1-4cdc-a8c1-ee4096ee35fb" />

