### PR TITLE
#Ng-460 [BUG] "Project Description" text area is not shown when it is empty

### DIFF
--- a/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.html
@@ -26,12 +26,10 @@
                     <p class="text-sm text-neutral-800">{{ notebook?.name ?? '' }}</p>
                 </div>
 
-              @if (notebook?.description) {
                 <div>
                   <h3 class="text-neutral-800 mb-2 font-semibold">Notebook Description</h3>
                   <div class="text-sm text-neutral-800 whitespace-pre-line" [innerHTML]="notebook?.description"></div>
                 </div>
-              }
 
                 <!-- TODO: Attachments list and actions -->
             </div>

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
@@ -39,13 +39,12 @@
         <p class="text-neutral-1000">{{ project.literature || '-' }}</p>
       </div>
 
-      @if (project.description || project.details) {
       <div>
         <h3 class="text-neutral-800 mb-2 font-semibold">Project Details</h3>
         <p class="text-neutral-1000" [innerHTML]="project.description"></p>
         <p class="text-neutral-1000 mt-4">{{ project.details }}</p>
       </div>
-      }
+      
       @if (project.attachments.length > 0) {
       <div>
         <h3 class="text-neutral-800 mb-2 font-semibold">Attachments</h3>


### PR DESCRIPTION
https://github.com/orgs/epam/projects/41/views/1?pane=issue&itemId=146678720&issue=epam%7CIndigo-ELN-v.-2.0%7C460 This bug fixes you can see in this PR. For both, 'Project Description' and 'Notebook Description' parts all of the optional fields (even they are empty) are visible now.