### PR TITLE
#Ng-391: [BUG] There is incorrect dashboard name on Project and Notebook

### DIFF
--- a/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.ts
@@ -33,7 +33,6 @@ export class NotebookInfoComponent {
     }
 
     notebookTeamConfig: TeamComponentConfig = {
-      title: 'Notebook Team',
       buildAccessEndpoint: (id: string) => `notebooks/${id}/access`,
     };
 

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -55,7 +55,6 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
 
   projectTeamConfig: TeamComponentConfig = {
-    title: 'Project Team',
     buildAccessEndpoint: (id: string) => `projects/${id}/access`,
   };
 

--- a/indigo-frontend/src/core/components/common/team/team.component.html
+++ b/indigo-frontend/src/core/components/common/team/team.component.html
@@ -3,7 +3,7 @@
     class="flex items-center justify-between border-b border-b-neutral-200 pb-3"
   >
     <div class="flex items-center gap-2">
-      <h2 class="font-semibold text-base">{{ config.title }}</h2>
+      <h2 class="font-semibold text-base">Team</h2>
       <eln-counter [count]="teamVm().length" variant="grey" size="large" />
     </div>
   </div>

--- a/indigo-frontend/src/core/components/common/team/team.config.ts
+++ b/indigo-frontend/src/core/components/common/team/team.config.ts
@@ -1,5 +1,4 @@
 // Config interface to adapt component to entity context (project, notebook, etc.)
 export interface TeamComponentConfig {
-    title?: string; // e.g. 'Team' or 'Notebook Team'
     buildAccessEndpoint: (entityId: string) => string; // e.g. projects/{id}/access or notebooks/{id}/access
 }


### PR DESCRIPTION
There are fixes for this bug: https://github.com/orgs/epam/projects/41/views/1?pane=issue&itemId=142352244&issue=epam%7CIndigo-ELN-v.-2.0%7C379

Instead of the different titles for the project and notebook team information, now we use the same one ('Team') based on the requirements.