### PR TITLE
#Ng-367: [BUG] Incorrect error message is shown when user tries to add too large file

### DIFF
--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -19,6 +19,8 @@ import { NotebookAddComponent } from '@pages/notebook/notebook-add/notebook-add.
 import {
   ProjectOverviewWidgetDirective
 } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
+import { NotificationService } from '@/core/services/notification/notification.service';
+import { NotificationType } from '@/core/types/notification.i';
 
 enum projectInfoModalEnum {
   EDIT = 'edit',
@@ -53,6 +55,7 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
   isUploadingAttachment = false;
 
   private destroy$ = new Subject<void>();
+  private notificationService = inject(NotificationService);
 
   projectTeamConfig: TeamComponentConfig = {
     title: 'Project Team',

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -19,8 +19,6 @@ import { NotebookAddComponent } from '@pages/notebook/notebook-add/notebook-add.
 import {
   ProjectOverviewWidgetDirective
 } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
-import { NotificationService } from '@/core/services/notification/notification.service';
-import { NotificationType } from '@/core/types/notification.i';
 
 enum projectInfoModalEnum {
   EDIT = 'edit',
@@ -55,7 +53,6 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
   isUploadingAttachment = false;
 
   private destroy$ = new Subject<void>();
-  private notificationService = inject(NotificationService);
 
   projectTeamConfig: TeamComponentConfig = {
     title: 'Project Team',

--- a/indigo-frontend/src/core/components/common/file-upload/file-upload.component.ts
+++ b/indigo-frontend/src/core/components/common/file-upload/file-upload.component.ts
@@ -11,6 +11,8 @@ import {
 import { take } from 'rxjs';
 import { FileSizePipe } from './file-size.pipe';
 import { fileTypeConfig } from './file-upload.config';
+import { NotificationService } from '@/core/services/notification/notification.service';
+import { NotificationType } from '@/core/types/notification.i';
 
 @Component({
   imports: [CommonModule, FileSizePipe],
@@ -33,6 +35,8 @@ export class FileUploadComponent implements OnInit {
   files: File[] = [];
   previews: string[] = [];
   today = Date.now();
+
+  private notificationService = inject(NotificationService);
 
   ngOnInit(): void {
     this.userService.user$.pipe(take(1)).subscribe((user) => {
@@ -65,8 +69,11 @@ export class FileUploadComponent implements OnInit {
       }
 
       if (file.size > this.maxSizeMB * 1024 * 1024) {
-        alert(`File too large: ${file.name} (Max: ${this.maxSizeMB}MB)`);
-        return null;
+        this.notificationService.notify({
+          type: NotificationType.Error,
+          message: `File '${file.name}' is too large. Max size is ${file.size}MB.`,
+          isInline: false
+        });
       }
 
       this.previewFile(file);

--- a/indigo-frontend/src/core/components/common/file-upload/file-upload.component.ts
+++ b/indigo-frontend/src/core/components/common/file-upload/file-upload.component.ts
@@ -62,10 +62,11 @@ export class FileUploadComponent implements OnInit {
   handleFiles(fileList: FileList) {
     const files = Array.from(fileList).map((file) => {
       if (this.mimeTypes.length && !this.mimeTypes.includes(file.type)) {
-        alert(
-          `Invalid file type: ${file.name}, Please upload files with extensions ${this.allowedTypes.join(', ')}`,
-        );
-        return null;
+        this.notificationService.notify({
+          type: NotificationType.Error,
+          message: `Invalid file type: ${file.name}, Please upload files with extensions ${this.allowedTypes.join(', ')}`,
+          isInline: false
+        })
       }
 
       if (file.size > this.maxSizeMB * 1024 * 1024) {


### PR DESCRIPTION
The bug mentioned in this ticket: https://github.com/orgs/epam/projects/41/views/1?pane=issue&itemId=141976163&issue=epam%7CIndigo-ELN-v.-2.0%7C367 concerns an incorrect text message when a user tries to attach a file larger than 5 MB on the "Project Description" widget. This part has been fixed, and not only that, this case was handled with "window.alert", which caused inconsistencies with the design and project structure. I replaced it with notificationService. I also replaced the "window.alert" with notificationService in the case where an error message should be displayed when the file type is incorrect.