### PR TITLE
fix: change placeholder for teams input

### DIFF
--- a/indigo-frontend/src/core/components/common/team/team.component.html
+++ b/indigo-frontend/src/core/components/common/team/team.component.html
@@ -18,7 +18,7 @@
         [multiple]="true"
         [closeOnSelect]="false"
         [searchable]="true"
-        placeholder="Add users..."
+        placeholder="Emails, comma separated"
         [(ngModel)]="selectedUserIds"
         (change)="onUsersSelectedIds(selectedUserIds)"
         [clearable]="true"


### PR DESCRIPTION
Was: Add users 
Now: Emails, comma separated

<img width="2607" height="1448" alt="image" src="https://github.com/user-attachments/assets/ed1369eb-d6c1-435a-8c2b-e8746ddc38d1" />
