### PR TITLE
#Ng-420: [BUG] Attachment image for .xlsx file is shown incorrect

### DIFF
--- a/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
+++ b/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
@@ -42,6 +42,8 @@ export class AttachmentComponent implements OnDestroy {
       case 'docx':
         return 'indicon-file-text';
       case 'png':
+      case 'jpg':
+      case 'jpeg':
         return 'indicon-image';
       case 'xls':
       case 'xlsx':

--- a/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
+++ b/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
@@ -38,13 +38,14 @@ export class AttachmentComponent implements OnDestroy {
     const extension = this.attachment.name.split('.').pop();
     switch (extension) {
       case 'pdf':
-      case 'xlsx':
-      case 'xls':
       case 'doc':
       case 'docx':
         return 'indicon-file-text';
       case 'png':
         return 'indicon-image';
+      case 'xls':
+      case 'xlsx':
+        return 'indicon-table';
       default:
         return 'indicon-file';
     }


### PR DESCRIPTION
In this PR I fixed this bug https://github.com/orgs/epam/projects/41/views/1?pane=issue&itemId=144659285&issue=epam%7CIndigo-ELN-v.-2.0%7C420 by correctly defining the icon for the file type .xlsx or even .xls.

I also decided to add logic in the switch/case operator for both the .jpg and .jpeg file types, since they were not mentioned at all and displayed the icon like .txt files, but it makes sense that they should display the same icon as .png.