### PR TITLE
fix: add snak-bar for showing an error with according text

### DIFF
--- a/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
@@ -11,7 +11,7 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
 import { catchError, of } from 'rxjs';
 import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
-
+import { MatSnackBar } from '@angular/material/snack-bar';
 @Component({
   standalone: true,
   selector: 'eln-notebook-edit',
@@ -26,6 +26,7 @@ import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
 })
 export class NotebookEditComponent {
   notebookId: string;
+  private snackBar = inject(MatSnackBar);
   dialogRef = inject(MatDialogRef);
   notebook: Partial<Notebook> = {};
   fields: FormlyFieldConfig[] = [
@@ -82,9 +83,10 @@ export class NotebookEditComponent {
       })
       .pipe(
         catchError((editError) => {
-          alert(
-            `Error: ${editError?.error[0].message || 'There was an error updating notebook, please try again later.'}`,
-          );
+          const errorMsg =
+            editError.error[0]?.message ||
+            'There was an error creating the notebook, please try again later.';
+          this.snackBar.open(errorMsg, 'Close', { duration: 5000 });
           return of(null);
         }),
       )

--- a/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
@@ -11,7 +11,9 @@ import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
 import { catchError, of } from 'rxjs';
 import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { NotificationService } from '@/core/services/notification/notification.service';
+import { NotificationType } from '@/core/types/notification.i';
+
 @Component({
   standalone: true,
   selector: 'eln-notebook-edit',
@@ -26,7 +28,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 })
 export class NotebookEditComponent {
   notebookId: string;
-  private snackBar = inject(MatSnackBar);
+  private notificationService = inject(NotificationService);
   dialogRef = inject(MatDialogRef);
   notebook: Partial<Notebook> = {};
   fields: FormlyFieldConfig[] = [
@@ -86,7 +88,12 @@ export class NotebookEditComponent {
           const errorMsg =
             editError.error[0]?.message ||
             'There was an error creating the notebook, please try again later.';
-          this.snackBar.open(errorMsg, 'Close', { duration: 5000 });
+
+          this.notificationService.notify({
+            message: errorMsg,
+            type: NotificationType.Error,
+            isInline: false,
+          });
           return of(null);
         }),
       )


### PR DESCRIPTION
<img width="2633" height="1457" alt="image" src="https://github.com/user-attachments/assets/42112a7c-678d-4121-abd9-976df3ba91b8" />
added snakbar,  now validation error message is displayed with the validation rule.


but if we want to use figma`s designed modal we should use:
catchError((editError) => {
          const errorMessage =
            editError.error?.\[0]?.message ||
           editError.error?.message ||
            editError.message ||
            'An error occurred while updating the notebook';
           this.notificationService.notify({
            message: errorMessage,
            type: NotificationType.Error,
            isInline: false,
          });
          return of(null);
        }),
with result:
<img width="2771" height="1582" alt="image" src="https://github.com/user-attachments/assets/92a1ff05-22ed-47a9-8f69-a153036f57ed" />


