### PR TITLE
#Ng-443: [BUG] Templates are shown for user without MANAGE_TEMPLATES permissions

### DIFF
--- a/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
@@ -43,7 +43,7 @@ export class SidebarComponent {
       name: 'Templates',
       icon: 'indicon-layers',
       path: '/templates',
-      requiredPermission: ApplicationPermission.MANAGE_DICTIONARIES,
+      requiredPermission: ApplicationPermission.MANAGE_TEMPLATES,
     },
     {
       name: 'Dictionaries',

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
@@ -43,6 +43,7 @@ export class SidebarComponent {
       name: 'Templates',
       icon: 'indicon-layers',
       path: '/templates',
+      requiredPermission: ApplicationPermission.MANAGE_DICTIONARIES,
     },
     {
       name: 'Dictionaries',


### PR DESCRIPTION
After the fixes for this bug: https://github.com/orgs/epam/projects/41/views/1?filterQuery=giga&pane=issue&itemId=145621667&issue=epam%7CIndigo-ELN-v.-2.0%7C443 the sidebar component shows only the  menu items which are appropriated regarding the permissions.