### PR TITLE
#Ng-445: [BUG] When opening some projects, the Project Info page opens in the middle, and you need to scroll up to see all the information

### DIFF
--- a/indigo-frontend/src/core/components/common/animated-route-container/animated-route-container.component.html
+++ b/indigo-frontend/src/core/components/common/animated-route-container/animated-route-container.component.html
@@ -12,7 +12,7 @@
   [@slideDownAnimation]="
     animationType === 'slideDown' ? prepareRouteTransition(outlet) : null
   "
-  class="relative w-full h-full"
+  class="relative w-full"
 >
   <ng-content></ng-content>
 </div>

--- a/indigo-frontend/src/core/components/layout/master.component.html
+++ b/indigo-frontend/src/core/components/layout/master.component.html
@@ -45,7 +45,7 @@
   <div class="flex flex-1 gap-4 p-4 overflow-hidden min-h-0">
     <eln-sidebar></eln-sidebar>
 
-    <main class="flex-1 overflow-y-auto p-1">
+    <main #content class="flex-1 overflow-y-auto p-1">
       <router-outlet></router-outlet>
     </main>
   </div>

--- a/indigo-frontend/src/core/components/layout/master.component.ts
+++ b/indigo-frontend/src/core/components/layout/master.component.ts
@@ -1,6 +1,6 @@
 import { UserService } from '@/core/services/user.service';
 import { CommonModule } from '@angular/common';
-import { Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, ElementRef, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatRippleModule } from '@angular/material/core';
@@ -8,9 +8,10 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatSidenavModule } from '@angular/material/sidenav';
-import { Router, RouterOutlet } from '@angular/router';
+import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { AuthenticatorService } from '@aws-amplify/ui-angular';
-import { Subject, takeUntil } from 'rxjs';
+import { Observable, Subject, takeUntil } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import { SidebarComponent } from './partials/sidebar/sidebar.component';
 import { GlobalSearchComponent } from '@pages/search/global-search/global-search.component';
 import { MatDialog } from '@angular/material/dialog';
@@ -44,6 +45,8 @@ export class MasterComponent implements OnInit, OnDestroy {
   userName = 'John D.';
   userAvatar = 'assets/avatar-placeholder.png';
 
+  @ViewChild('content', {static: true}) content!: ElementRef<HTMLElement>;
+
   logout() {
     this.authenticatorService.signOut();
     this.router.navigateByUrl('/');
@@ -53,6 +56,11 @@ export class MasterComponent implements OnInit, OnDestroy {
     this.userService.user$.pipe(takeUntil(this.destroy$)).subscribe((user) => {
       this.userName = `${user.displayName}`;
     });
+
+    (this.router.events as Observable<NavigationEnd>).pipe(filter((e) => e instanceof NavigationEnd))
+    .subscribe(() => {
+      this.content.nativeElement.scrollTop = 0;
+    })
   }
 
   ngOnDestroy(): void {

--- a/indigo-frontend/src/core/components/layout/master.component.ts
+++ b/indigo-frontend/src/core/components/layout/master.component.ts
@@ -57,7 +57,7 @@ export class MasterComponent implements OnInit, OnDestroy {
       this.userName = `${user.displayName}`;
     });
 
-    (this.router.events as Observable<NavigationEnd>).pipe(filter((e) => e instanceof NavigationEnd))
+    (this.router.events as Observable<NavigationEnd>).pipe(filter((e) => e instanceof NavigationEnd), takeUntil(this.destroy$))
     .subscribe(() => {
       this.content.nativeElement.scrollTop = 0;
     })


### PR DESCRIPTION
This bug: https://github.com/orgs/epam/projects/41/views/1?filterQuery=giga&pane=issue&itemId=145739318&issue=epam%7CIndigo-ELN-v.-2.0%7C445 is fixed by removing the vertical scrollbar at all when that is no need to scroll down, it properly responses to the QA report.

When there is necessary t boe a scrollbar then it appears and appears  at the top.