### PR TITLE
#Ng-482: There is incorrect text for already added members into dropdown on Team section for Project/Notebook levels

### DIFF
--- a/indigo-frontend/src/core/components/common/team/team.component.html
+++ b/indigo-frontend/src/core/components/common/team/team.component.html
@@ -36,7 +36,7 @@
             </div>
             <div class="flex items-center">
               <span class="text-xs" [class.text-neutral-500]="item.added">{{
-                item.added ? 'Already added' : ''
+                item.added ? 'Already Added' : ''
               }}</span>
             </div>
           </div>


### PR DESCRIPTION
The text for added users in teams section are updated based on the mockups for both, notebook and project levels: https://github.com/orgs/epam/projects/41/views/1?pane=issue&itemId=147512220&issue=epam%7CIndigo-ELN-v.-2.0%7C482.