### PR TITLE
#Ng-483: [BUG] Inactive button and some hovered elements look incorrect

### DIFF
--- a/indigo-frontend/src/core/components/common/button/button.variant.ts
+++ b/indigo-frontend/src/core/components/common/button/button.variant.ts
@@ -14,7 +14,7 @@ export const ButtonVariant = cva(
     variants: {
       variant: {
         green: ['bg-green-400', 'hover:bg-green-300'],
-        blue: ['bg-primary-400', 'hover:bg-primary-500', 'text-neutral'],
+        blue: ['bg-primary-400', 'hover:bg-primary-500', 'text-neutral', 'disabled:text-neutral-500'],
         'blue-outline': [
           'bg-neutral',
           'text-primary-400',

--- a/indigo-frontend/src/core/components/common/button/button.variant.ts
+++ b/indigo-frontend/src/core/components/common/button/button.variant.ts
@@ -14,7 +14,14 @@ export const ButtonVariant = cva(
     variants: {
       variant: {
         green: ['bg-green-400', 'hover:bg-green-300'],
-        blue: ['bg-primary-400', 'hover:bg-primary-500', 'text-neutral', 'disabled:text-neutral-500'],
+        blue: [
+          'bg-primary-400', 
+          'hover:bg-primary-500', 
+          'text-neutral', 
+          'disabled:text-neutral-600', 
+          'disabled:border', 
+          'disabled:border-neutral-300'
+        ],
         'blue-outline': [
           'bg-neutral',
           'text-primary-400',

--- a/indigo-frontend/src/core/components/layout/master.component.html
+++ b/indigo-frontend/src/core/components/layout/master.component.html
@@ -35,8 +35,6 @@
         <span>{{ userName }}</span>
       </div>
       <mat-menu #userMenu="matMenu">
-        <button mat-menu-item>Profile</button>
-        <button mat-menu-item>Settings</button>
         <button mat-menu-item (click)="logout()">Logout</button>
       </mat-menu>
     </div>

--- a/indigo-frontend/src/core/components/layout/master.component.html
+++ b/indigo-frontend/src/core/components/layout/master.component.html
@@ -24,7 +24,7 @@
         <em class="indicon-bell text-neutral relative -top-1"></em>
       </button>
       <div
-        class="flex items-center gap-2 hover:bg-neutral p-2 rounded-sm cursor-pointer text-neutral hover:text-neutral-100"
+        class="flex items-center gap-2 p-2 rounded-sm text-neutral"
         [matMenuTriggerFor]="userMenu"
       >
         <img


### PR DESCRIPTION
Every color mismatches mentioned on this bug report: https://github.com/orgs/epam/projects/41/views/1?filterQuery=giga&pane=issue&itemId=147519339&issue=epam%7CIndigo-ELN-v.-2.0%7C483 is fixed. 

Also, I had the communication with Daria (designer) and Roman (BA) regarding this bug report. Daria said the user icon and her/his name should not be clickable and we can remove the dropdown menu at all. From the dropdown menu items only 'Logout' is necessary to be but in the different place, on the panel.

And after the communication with Roman we found out that the current states of some buttons are not properly handled based on the user roles, because it does not follow this documentation: https://kb.epam.com/pages/viewpage.action?pageId=2485421752 (permissions naming on notebook level should be uploaded by Roman, later). For example, here user has the permission to add the new experiment, but the appropriate button is disabled - 
<img width="1375" height="484" alt="permissions-handle" src="https://github.com/user-attachments/assets/bed95f8d-d904-4e27-8c79-ce31e87c2c8f" />


QUESTIONS: Based on what I mentioned above, maybe we can create two tickets, first regarding the properly created 'Log Out' button and second, for handling the permissions and user interactions based on that?
