### PR TITLE
fix: add missing Sorting by text for notebooks and templates after tests

### DIFF
--- a/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.ts
@@ -63,12 +63,12 @@ export class NotebookListComponent
         loadUrl: `projects/${this.projectId}/notebooks`,
         sortOptions: [
           {
-            label: 'Sort by: Earliest',
+            label: 'Sorting by: Earliest',
             value: 'createdAt',
             defaultOrder: 'EARLIEST',
           },
           {
-            label: 'Sort by: Latest',
+            label: 'Sorting by: Latest',
             value: 'createdAt',
             defaultOrder: 'LATEST',
           },

--- a/indigo-frontend/src/app/pages/template/template-list/template-list.component.ts
+++ b/indigo-frontend/src/app/pages/template/template-list/template-list.component.ts
@@ -60,12 +60,12 @@ export class TemplateListComponent
       loadUrl: 'templates',
       sortOptions: [
         {
-          label: 'Sort by: Earliest',
+          label: 'Sorting by: Earliest',
           value: 'createdAt',
           defaultOrder: 'EARLIEST',
         },
         {
-          label: 'Sort by: Latest',
+          label: 'Sorting by: Latest',
           value: 'createdAt',
           defaultOrder: 'LATEST',
         },


### PR DESCRIPTION
<img width="2278" height="938" alt="image" src="https://github.com/user-attachments/assets/8a70b3c4-00b0-4216-9ebf-fac18984ff15" />
<img width="2269" height="1214" alt="image" src="https://github.com/user-attachments/assets/a1d069d0-4c65-4b2f-bf0c-afe099de113f" />
