### PR TITLE
[FE] Implement global error handling #430

### DIFF
--- a/backend/common/common/src/main/java/com/epam/indigoeln/common/exception/AccessDeniedException.java
+++ b/backend/common/common/src/main/java/com/epam/indigoeln/common/exception/AccessDeniedException.java
@@ -6,16 +6,16 @@ import java.util.UUID;
 
 public class AccessDeniedException extends RuntimeException {
 
-    public AccessDeniedException(Enum<?> entityType, UUID id, String currentUser) {
-        super(String.format("%s %s not found or not accessible; current user %s", entityType, id, currentUser));
+    public AccessDeniedException(Enum<?> entityType, UUID id) {
+        super(String.format("%s %s not found or not accessible", entityType, id));
     }
 
-    public AccessDeniedException(Enum<?> operation, String currentUser) {
-        super(String.format("Operation not permitted: %s; current user %s", operation, currentUser));
+    public AccessDeniedException(Enum<?> operation) {
+        super(String.format("Operation not permitted: %s", operation));
     }
 
-    public AccessDeniedException(Enum<?> entityType, UUID id, Enum<?> operation, @Nullable Enum<?> currentLevel, String currentUser) {
-        super(String.format("Operation not permitted: %s on %s %s; current access %s doesn't allow it; current user %s", operation, entityType, id, currentLevel, currentUser));
+    public AccessDeniedException(Enum<?> entityType, UUID id, Enum<?> operation, @Nullable Enum<?> currentLevel) {
+        super(String.format("Operation not permitted: %s on %s %s; current access %s doesn't allow it", operation, entityType, id, currentLevel));
     }
 
     public AccessDeniedException(String missingUser) {

--- a/backend/eln/eln-core/src/main/java/com/epam/indigoeln/eln/repository/BaseRepository.java
+++ b/backend/eln/eln-core/src/main/java/com/epam/indigoeln/eln/repository/BaseRepository.java
@@ -1,6 +1,7 @@
 package com.epam.indigoeln.eln.repository;
 
 import com.epam.indigoeln.common.exception.AccessDeniedException;
+import com.epam.indigoeln.common.exception.EntityNotFoundException;
 import com.epam.indigoeln.common.util.ModelUtil;
 import com.epam.indigoeln.eln.entity.IdentifiableEntity;
 import com.epam.indigoeln.eln.model.EntityType;
@@ -8,7 +9,6 @@ import com.epam.indigoeln.eln.model.Page;
 import com.epam.indigoeln.eln.model.Paging;
 import com.epam.indigoeln.eln.service.UserService;
 import com.epam.indigoeln.eln.util.Conditions;
-import com.epam.indigoeln.common.exception.EntityNotFoundException;
 import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.panache.common.Sort;
@@ -60,7 +60,7 @@ public abstract class BaseRepository<E extends IdentifiableEntity> implements Pa
         E entity = query
                 .withHint("jakarta.persistence.loadgraph", entityGraph)
                 .singleResultOptional()
-                .orElseThrow(() -> new AccessDeniedException(entityType, id, userService.getCurrentUser().getUsername()));
+                .orElseThrow(() -> new AccessDeniedException(entityType, id));
         return mapper.apply(entity);
     }
 

--- a/backend/eln/eln-core/src/main/java/com/epam/indigoeln/eln/service/ACLService.java
+++ b/backend/eln/eln-core/src/main/java/com/epam/indigoeln/eln/service/ACLService.java
@@ -51,7 +51,7 @@ public class ACLService {
         if (isUserRolesAllow(operation)) {
             return;
         }
-        throw new AccessDeniedException(operation, userService.getCurrentUser().getUsername());
+        throw new AccessDeniedException(operation);
     }
 
     public void ensureAccess(ProjectEntity project, ApplicationPermission operation) {
@@ -60,7 +60,7 @@ public class ACLService {
         }
         AccessLevel currentAccess = project.getCalculatedInfo() != null ? project.getCalculatedInfo().getCurrentAccess() : NONE;
         if (!operation.isAllowedBy(currentAccess)) {
-            throw new AccessDeniedException(EntityType.PROJECT, project.getId(), operation, currentAccess, userService.getCurrentUser().getUsername());
+            throw new AccessDeniedException(EntityType.PROJECT, project.getId(), operation, currentAccess);
         }
     }
 
@@ -70,7 +70,7 @@ public class ACLService {
         }
         AccessLevel currentAccess = notebook.getCalculatedInfo() != null ? notebook.getCalculatedInfo().getCurrentAccess() : NONE;
         if (!operation.isAllowedBy(currentAccess)) {
-            throw new AccessDeniedException(EntityType.NOTEBOOK, notebook.getId(), operation, currentAccess, userService.getCurrentUser().getUsername());
+            throw new AccessDeniedException(EntityType.NOTEBOOK, notebook.getId(), operation, currentAccess);
         }
     }
 
@@ -80,7 +80,7 @@ public class ACLService {
         }
         AccessLevel currentAccess = experiment.getCalculatedInfo() != null ? experiment.getCalculatedInfo().getCurrentAccess() : NONE;
         if (!operation.isAllowedBy(currentAccess)) {
-            throw new AccessDeniedException(EntityType.EXPERIMENT, experiment.getId(), operation, currentAccess, userService.getCurrentUser().getUsername());
+            throw new AccessDeniedException(EntityType.EXPERIMENT, experiment.getId(), operation, currentAccess);
         }
     }
 

--- a/indigo-frontend/src/app/app.config.local.ts
+++ b/indigo-frontend/src/app/app.config.local.ts
@@ -2,15 +2,10 @@ import { ChipGridFieldComponent } from '@/core/components/formly/fields/chip-gri
 import { InputFieldComponent } from '@/core/components/formly/fields/input-field.component';
 import { ElnWrapperFormField } from '@/core/components/formly/wrappers/field-wrapper.component';
 
-import {
-  HTTP_INTERCEPTORS,
-  provideHttpClient,
-  withInterceptors,
-  withInterceptorsFromDi,
-  withXsrfConfiguration,
-} from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import {
   ApplicationConfig,
+  ErrorHandler,
   importProvidersFrom,
   provideZoneChangeDetection,
 } from '@angular/core';
@@ -24,19 +19,20 @@ import { FormlyMaterialModule } from '@ngx-formly/material';
 import { FormlyMatDatepickerModule } from '@ngx-formly/material/datepicker';
 import { routes } from './app.routes.local';
 import {
-  provideKeycloak,
+  AutoRefreshTokenService,
   createInterceptorCondition,
+  INCLUDE_BEARER_TOKEN_INTERCEPTOR_CONFIG,
   IncludeBearerTokenCondition,
   includeBearerTokenInterceptor,
-  INCLUDE_BEARER_TOKEN_INTERCEPTOR_CONFIG,
+  provideKeycloak,
+  UserActivityService,
   withAutoRefreshToken,
-  AutoRefreshTokenService,
-  UserActivityService
 } from 'keycloak-angular';
+import { ELNErrorHandler } from '@core/services/error-handler';
 
 const urlCondition = createInterceptorCondition<IncludeBearerTokenCondition>({
   urlPattern: /^(http:\/\/localhost:8080)(\/.*)?$/i,
-  bearerPrefix: 'Bearer'
+  bearerPrefix: 'Bearer',
 });
 
 export const appConfig: ApplicationConfig = {
@@ -50,7 +46,8 @@ export const appConfig: ApplicationConfig = {
       },
       initOptions: {
         onLoad: 'login-required',
-        silentCheckSsoRedirectUri: window.location.origin + '/assets/silent-check-sso.html',
+        silentCheckSsoRedirectUri:
+          window.location.origin + '/assets/silent-check-sso.html',
         redirectUri: window.location.origin + '/',
       },
       features: [
@@ -110,5 +107,6 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideAnimationsAsync(),
     provideHttpClient(withInterceptors([includeBearerTokenInterceptor])),
+    { provide: ErrorHandler, useClass: ELNErrorHandler },
   ],
 };

--- a/indigo-frontend/src/app/app.config.ts
+++ b/indigo-frontend/src/app/app.config.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/common/http';
 import {
   ApplicationConfig,
+  ErrorHandler,
   importProvidersFrom,
   provideZoneChangeDetection,
 } from '@angular/core';
@@ -24,6 +25,7 @@ import { FormlyMatDatepickerModule } from '@ngx-formly/material/datepicker';
 import { routes } from './app.routes';
 import { SelectFieldComponent } from '@/core/components/formly/fields/select-field.component';
 import { SelectChipsComponent } from '@/core/components/formly/fields/select-chips.component';
+import { ELNErrorHandler } from '@core/services/error-handler';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -87,5 +89,6 @@ export const appConfig: ApplicationConfig = {
       withInterceptorsFromDi(),
     ),
     { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true },
+    { provide: ErrorHandler, useClass: ELNErrorHandler },
   ],
 };

--- a/indigo-frontend/src/app/pages/experiment/sample-search/sample-search.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/sample-search/sample-search.component.ts
@@ -17,7 +17,6 @@ import {
 } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
-import { InputComponent } from '@core/components/common/input/input.component';
 import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
 import {
   FindSamplesRequest,
@@ -28,7 +27,6 @@ import {
 } from '@core/types/entities/experiments/search.i';
 import {
   MatExpansionPanel,
-  MatExpansionPanelDescription,
   MatExpansionPanelHeader,
   MatExpansionPanelTitle,
 } from '@angular/material/expansion';
@@ -38,7 +36,6 @@ import {
   DictionaryItemRef,
 } from '@core/types/entities/dictionary.i';
 import { NumericSearchComponent } from '@core/components/common/numeric-search/numeric-search.component';
-import { MatChipRow, MatChipSet } from '@angular/material/chips';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import {
   ColumnDefDirective,
@@ -65,16 +62,15 @@ import {
   setEnabled,
   textSearchSummary,
 } from '@core/utils/search.util';
-import { ButtonComponent } from '@core/components/common/button/button.component';
 import { ExperimentDetailService } from '@core/services/experiment/experiment-detail.service';
+import { MatIcon, MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatButtonModule } from '@angular/material/button';
 
 export interface SampleSearchDialogData {
   experimentId: UUID;
   reactionAnchor: ReactionAnchor;
 }
-import { MatIcon, MatIconModule } from '@angular/material/icon';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   standalone: true,
@@ -255,12 +251,8 @@ export class SampleSearchComponent implements OnInit {
         'post',
         `samples/${sample.id}/${mark ? 'mark' : 'unmark'}`,
       )
-      .subscribe({
-        next: (response) =>
-          this.loader.replace((s) => s.id === sample.id, response),
-        error: (error) => {
-          console.error('Failed to mark/unmark sample: ', error);
-        },
+      .subscribe((response) => {
+        this.loader.replace((s) => s.id === sample.id, response);
       });
   }
 

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
@@ -9,7 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
-import { catchError, of, tap } from 'rxjs';
+import { tap } from 'rxjs';
 import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
 
 @Component({
@@ -78,13 +78,6 @@ export class NotebookAddComponent {
       .pipe(
         tap(() => {
           this.dialogRef.close('refresh');
-        }),
-        catchError((createError) => {
-          const errorMsg =
-            createError.error[0]?.message ||
-            'There was an error creating the notebook, please try again later.';
-          this.snackBar.open(errorMsg, 'Close', { duration: 5000 });
-          return of(null);
         }),
       )
       .subscribe();

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
@@ -6,10 +6,8 @@ import { Component, inject } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
-import { tap } from 'rxjs';
 import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
 
 @Component({
@@ -27,7 +25,6 @@ import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
 export class NotebookAddComponent {
   projectId: string;
   dialogRef = inject(MatDialogRef);
-  private snackBar = inject(MatSnackBar);
   fields: FormlyFieldConfig[] = [
     {
       type: 'input',
@@ -75,11 +72,8 @@ export class NotebookAddComponent {
             ? toHTML(data.description)
             : data.description,
       })
-      .pipe(
-        tap(() => {
-          this.dialogRef.close('refresh');
-        }),
-      )
-      .subscribe();
+      .subscribe(() => {
+        this.dialogRef.close('refresh');
+      });
   }
 }

--- a/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
@@ -5,14 +5,12 @@ import { NotebookDialogData } from '@/core/types/entities/notebook-dialog-data.i
 import { CommonModule } from '@angular/common';
 import { Component, Inject, inject } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
-import { catchError, of } from 'rxjs';
 import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
 import { NotificationService } from '@/core/services/notification/notification.service';
-import { NotificationType } from '@/core/types/notification.i';
 
 @Component({
   standalone: true,
@@ -83,20 +81,6 @@ export class NotebookEditComponent {
             ? toHTML(data.description)
             : data.description,
       })
-      .pipe(
-        catchError((editError) => {
-          const errorMsg =
-            editError.error[0]?.message ||
-            'There was an error creating the notebook, please try again later.';
-
-          this.notificationService.notify({
-            message: errorMsg,
-            type: NotificationType.Error,
-            isInline: false,
-          });
-          return of(null);
-        }),
-      )
       .subscribe((result) => {
         if (result) this.dialogRef.close('refresh');
       });

--- a/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
@@ -81,8 +81,8 @@ export class NotebookEditComponent {
             ? toHTML(data.description)
             : data.description,
       })
-      .subscribe((result) => {
-        if (result) this.dialogRef.close('refresh');
+      .subscribe(() => {
+        this.dialogRef.close('refresh');
       });
   }
 }

--- a/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
@@ -7,7 +7,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
-import { catchError, EMPTY, tap } from 'rxjs';
+import { tap } from 'rxjs';
 import { Project } from '@core/types/entities/project.i';
 import { Router } from '@angular/router';
 import { NotificationService } from '@core/services/notification/notification.service';
@@ -109,14 +109,6 @@ export class ProjectAddComponent implements OnInit {
             isInline: false,
           });
         }),
-        catchError((createError) => {
-          this.notificationService.notify({
-            message: createError.message,
-            type: NotificationType.Error,
-            isInline: false,
-          });
-          return EMPTY;
-        }),
       )
       .subscribe();
   }
@@ -139,15 +131,6 @@ export class ProjectAddComponent implements OnInit {
             type: NotificationType.Success,
             isInline: false,
           });
-        }),
-        catchError((updateError) => {
-          this.notificationService.notify({
-            message: updateError.message,
-            type: NotificationType.Error,
-            isInline: false,
-          });
-
-          return EMPTY;
         }),
       )
       .subscribe();

--- a/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-add/project-add.component.ts
@@ -98,19 +98,16 @@ export class ProjectAddComponent implements OnInit {
             ? toHTML(data.description)
             : data.description,
       })
-      .pipe(
-        tap((newProject: Project) => {
-          this.dialogRef.close('refresh');
-          this.router.navigate(['/projects', newProject.id]);
+      .subscribe((newProject: Project) => {
+        this.dialogRef.close('refresh');
+        this.router.navigate(['/projects', newProject.id]);
 
-          this.notificationService.notify({
-            message: `Project '${data.name}' has been successfully created`,
-            type: NotificationType.Success,
-            isInline: false,
-          });
-        }),
-      )
-      .subscribe();
+        this.notificationService.notify({
+          message: `Project '${data.name}' has been successfully created`,
+          type: NotificationType.Success,
+          isInline: false,
+        });
+      });
   }
 
   updateProject(data: Project) {

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -10,19 +10,17 @@ import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { from, of, Subject, take } from 'rxjs';
 import { catchError, concatMap, takeUntil } from 'rxjs/operators';
-import { FileUploadComponent } from "@/core/components/common/file-upload/file-upload.component";
+import { FileUploadComponent } from '@/core/components/common/file-upload/file-upload.component';
 import { Attachment } from '@/core/types/entities/attachment.i';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ProjectAddComponent } from '../project-add/project-add.component';
 import { TeamComponentConfig } from '@/core/components/common/team/team.config';
 import { NotebookAddComponent } from '@pages/notebook/notebook-add/notebook-add.component';
-import {
-  ProjectOverviewWidgetDirective
-} from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
+import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
 
 enum projectInfoModalEnum {
   EDIT = 'edit',
-  NOTEBOOK = 'notebook'
+  NOTEBOOK = 'notebook',
 }
 @Component({
   selector: 'eln-project-info',
@@ -35,7 +33,7 @@ enum projectInfoModalEnum {
     TeamComponent,
     CardComponent,
     FileUploadComponent,
-    ProjectOverviewWidgetDirective
+    ProjectOverviewWidgetDirective,
   ],
   templateUrl: './project-info.component.html',
 })
@@ -75,7 +73,7 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
     if (this.project) {
       // Remove the deleted attachment from the local array
       this.project.attachments = this.project.attachments.filter(
-        attachment => attachment.id !== attachmentId
+        (attachment) => attachment.id !== attachmentId,
       );
     }
   }
@@ -89,41 +87,42 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const formDatas = newFiles.map(file => {
+    const formDatas = newFiles.map((file) => {
       const formData = new FormData();
       formData.append('file', file, file.name);
       return formData;
     });
 
-    from(formDatas).pipe(
-      concatMap(formData => this.service.request<Attachment[]>(
-        'post',
-        `projects/${this.project!.id}/attachments`,
-        formData,
-      )),
-      catchError((err) => {
-        console.error('Failed to upload attachment:', err);
-        this.isUploadingAttachment = false;
-        return of(null);
-      }),
-      takeUntil(this.destroy$),
-    )
+    from(formDatas)
+      .pipe(
+        concatMap((formData) =>
+          this.service.request<Attachment[]>(
+            'post',
+            `projects/${this.project!.id}/attachments`,
+            formData,
+          ),
+        ),
+        takeUntil(this.destroy$),
+      )
       .subscribe({
         next: (attachments) => {
-          if (this.project && attachments) this.project.attachments = attachments;
+          if (this.project && attachments)
+            this.project.attachments = attachments;
         },
         error: (err) => {
           console.error('Upload error:', err);
-        }, complete: () => {
+        },
+        complete: () => {
           this.isUploadingAttachment = false;
-        }
+        },
       });
   }
 
   private loadProject(id: string): void {
     this.isLoading = true;
     this.hasError = false;
-    this.service.request<Project>('get', `projects/${id}`)
+    this.service
+      .request<Project>('get', `projects/${id}`)
       .pipe(
         takeUntil(this.destroy$),
         catchError((err) => {
@@ -131,13 +130,11 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
           this.hasError = true;
           this.isLoading = false;
           return of(null);
-        })
+        }),
       )
-      .subscribe({
-        next: (project) => {
-          this.isLoading = false;
-          if (project) this.project = project;
-        },
+      .subscribe((project) => {
+        this.isLoading = false;
+        if (project) this.project = project;
       });
   }
 
@@ -154,10 +151,12 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
 
     if (mode === projectInfoModalEnum.NOTEBOOK) {
       ref = this.dialog.open(NotebookAddComponent);
-      (ref.componentInstance as NotebookAddComponent).projectId = this.project.id;
+      (ref.componentInstance as NotebookAddComponent).projectId =
+        this.project.id;
     }
 
-    ref?.afterClosed()
+    ref
+      ?.afterClosed()
       .pipe(take(1))
       .subscribe((result) => {
         if (result === 'refresh') {

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -8,8 +8,8 @@ import { Project } from '@/core/types/entities/project.i';
 import { CommonModule } from '@angular/common';
 import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { from, of, Subject, take } from 'rxjs';
-import { catchError, concatMap, takeUntil } from 'rxjs/operators';
+import { finalize, from, Subject, take, tap } from 'rxjs';
+import { concatMap, takeUntil } from 'rxjs/operators';
 import { FileUploadComponent } from '@/core/components/common/file-upload/file-upload.component';
 import { Attachment } from '@/core/types/entities/attachment.i';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
@@ -102,19 +102,11 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
             formData,
           ),
         ),
+        finalize(() => (this.isUploadingAttachment = false)),
         takeUntil(this.destroy$),
       )
-      .subscribe({
-        next: (attachments) => {
-          if (this.project && attachments)
-            this.project.attachments = attachments;
-        },
-        error: (err) => {
-          console.error('Upload error:', err);
-        },
-        complete: () => {
-          this.isUploadingAttachment = false;
-        },
+      .subscribe((attachments) => {
+        if (this.project) this.project.attachments = attachments;
       });
   }
 
@@ -124,18 +116,12 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
     this.service
       .request<Project>('get', `projects/${id}`)
       .pipe(
-        takeUntil(this.destroy$),
-        catchError((err) => {
-          console.error('Failed to load project:', err);
-          this.hasError = true;
-          this.isLoading = false;
-          return of(null);
+        tap({
+          error: () => (this.hasError = true),
         }),
+        finalize(() => (this.isLoading = false)),
       )
-      .subscribe((project) => {
-        this.isLoading = false;
-        if (project) this.project = project;
-      });
+      .subscribe((project) => (this.project = project));
   }
 
   async openModal(mode: projectInfoModalEnum) {

--- a/indigo-frontend/src/app/pages/template/template-add/template-add.component.ts
+++ b/indigo-frontend/src/app/pages/template/template-add/template-add.component.ts
@@ -4,7 +4,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { ApiService } from '@core/services/api.service';
 import { toHTML } from 'ngx-editor';
-import { catchError, of, tap } from 'rxjs';
+import { tap } from 'rxjs';
 import { MatInputModule } from '@angular/material/input';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
@@ -24,7 +24,6 @@ import { Template } from '@core/types/entities/template.i';
   styleUrl: './template-add.component.scss',
 })
 export class TemplateAddComponent implements OnInit {
-
   template!: Template;
   dialogRef = inject(MatDialogRef);
   data = inject(MAT_DIALOG_DATA);
@@ -43,8 +42,7 @@ export class TemplateAddComponent implements OnInit {
     },
   ];
 
-  constructor(protected service: ApiService<any>) {
-  }
+  constructor(protected service: ApiService<any>) {}
 
   ngOnInit(): void {
     this.template = this.data?.template || null;
@@ -59,26 +57,20 @@ export class TemplateAddComponent implements OnInit {
     }
   }
 
-  createTemplates(data:  {name: string}) {
+  createTemplates(data: { name: string }) {
     this.service
       .create('templates', {
         ...data,
-        "templateTabs": [
+        templateTabs: [
           {
-            "name": "",
-            "components": [
-              {}
-            ]
-          }
-        ]
+            name: '',
+            components: [{}],
+          },
+        ],
       })
       .pipe(
         tap(() => {
           this.dialogRef.close('refresh');
-        }),
-        catchError((createError) => {
-          alert(createError.message);
-          return of(null);
         }),
       )
       .subscribe();
@@ -97,12 +89,7 @@ export class TemplateAddComponent implements OnInit {
         tap(() => {
           this.dialogRef.close('refresh');
         }),
-        catchError((updateError) => {
-          alert(updateError.message);
-          return of(null);
-        }),
       )
       .subscribe();
   }
-
 }

--- a/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
+++ b/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
@@ -11,7 +11,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { CardComponent } from '../card/card.component';
 import { ApiService } from '@/core/services/api.service';
-import { Subject, takeUntil } from 'rxjs';
+import { Subject } from 'rxjs';
 import { downloadBlob } from '@/core/utils/download.util';
 import { BytesConvertingPipe } from '@/core/pipes/bytesConverting.pipe';
 
@@ -74,10 +74,9 @@ export class AttachmentComponent implements OnDestroy {
           responseType: 'blob',
         },
       )
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: (blob: Blob | null) => downloadBlob(blob, this.attachment.name),
-      });
+      .subscribe((blob: Blob | null) =>
+        downloadBlob(blob, this.attachment.name),
+      );
   }
 
   deleteAttachment() {
@@ -86,10 +85,7 @@ export class AttachmentComponent implements OnDestroy {
         'delete',
         `projects/${this.projectId}/attachments/${this.attachment.id}`,
       )
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: () => this.attachmentDeleted.emit(this.attachment.id),
-      });
+      .subscribe(() => this.attachmentDeleted.emit(this.attachment.id));
   }
 
   ngOnDestroy() {

--- a/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
+++ b/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
@@ -1,17 +1,29 @@
 import { Attachment } from '@/core/types/entities/attachment.i';
 import { DatePipe } from '@angular/common';
-import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  Output,
+} from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { CardComponent } from '../card/card.component';
 import { ApiService } from '@/core/services/api.service';
-import { catchError, of, Subject, takeUntil } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 import { downloadBlob } from '@/core/utils/download.util';
 import { BytesConvertingPipe } from '@/core/pipes/bytesConverting.pipe';
 
 @Component({
   standalone: true,
-  imports: [CardComponent, MatMenuModule, MatIconModule, DatePipe, BytesConvertingPipe],
+  imports: [
+    CardComponent,
+    MatMenuModule,
+    MatIconModule,
+    DatePipe,
+    BytesConvertingPipe,
+  ],
   selector: 'eln-attachment',
   templateUrl: './attachment.component.html',
 })
@@ -27,8 +39,7 @@ export class AttachmentComponent implements OnDestroy {
 
   private destroy$ = new Subject<void>();
 
-  constructor(protected service: ApiService<Attachment>) { }
-
+  constructor(protected service: ApiService<Attachment>) {}
 
   get computedIcon() {
     if (this.icon.length) {
@@ -54,36 +65,31 @@ export class AttachmentComponent implements OnDestroy {
   }
 
   downloadAttachment() {
-    this.service.request<Blob>(
-      'get',
-      `project/${this.projectId}/attachments/${this.attachment.id}`,
-      undefined,
-      {
-        responseType: 'blob',
-      }
-    )
-      .pipe(
-        takeUntil(this.destroy$),
-        catchError((err) => {
-          console.error('Failed to download attachment:', err);
-          return of(null);
-        })
+    this.service
+      .request<Blob>(
+        'get',
+        `project/${this.projectId}/attachments/${this.attachment.id}`,
+        undefined,
+        {
+          responseType: 'blob',
+        },
       )
+      .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (blob: Blob | null) => downloadBlob(blob, this.attachment.name),
       });
   }
 
   deleteAttachment() {
-    this.service.request<void>('delete', `projects/${this.projectId}/attachments/${this.attachment.id}`)
-      .pipe(
-        takeUntil(this.destroy$),
-        catchError((err) => {
-          console.error('Failed to delete attachment:', err);
-          return of(null);
-        })
+    this.service
+      .request<void>(
+        'delete',
+        `projects/${this.projectId}/attachments/${this.attachment.id}`,
       )
-      .subscribe({ next: () => this.attachmentDeleted.emit(this.attachment.id) });
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.attachmentDeleted.emit(this.attachment.id),
+      });
   }
 
   ngOnDestroy() {

--- a/indigo-frontend/src/core/components/common/image/api-image.component.ts
+++ b/indigo-frontend/src/core/components/common/image/api-image.component.ts
@@ -19,10 +19,6 @@ export class ApiImageComponent {
   load() {
     this.api
       .request<Blob>('get', this.url, null, { responseType: 'blob' })
-      .subscribe({
-        next: (blob) => {
-          this.src = URL.createObjectURL(blob);
-        },
-      });
+      .subscribe((blob) => (this.src = URL.createObjectURL(blob)));
   }
 }

--- a/indigo-frontend/src/core/components/common/image/api-image.component.ts
+++ b/indigo-frontend/src/core/components/common/image/api-image.component.ts
@@ -23,9 +23,6 @@ export class ApiImageComponent {
         next: (blob) => {
           this.src = URL.createObjectURL(blob);
         },
-        error: (error) => {
-          console.error('Error loading image:', error);
-        },
       });
   }
 }

--- a/indigo-frontend/src/core/components/common/team/team.component.ts
+++ b/indigo-frontend/src/core/components/common/team/team.component.ts
@@ -108,11 +108,9 @@ export class TeamComponent implements OnInit {
           this.loading.update((l) => ({ ...l, suggestions: false })),
         ),
       )
-      .subscribe({
-        next: (list) => {
-          this.userSuggestions = list;
-          this.rebuildSuggestionsState();
-        },
+      .subscribe((list) => {
+        this.userSuggestions = list;
+        this.rebuildSuggestionsState();
       });
   }
 
@@ -150,9 +148,7 @@ export class TeamComponent implements OnInit {
           this.loading.update((l) => ({ ...l, addingUsers: false }));
         }),
       )
-      .subscribe({
-        next: () => this.handleSuccessfulUserAddition(),
-      });
+      .subscribe(() => this.handleSuccessfulUserAddition());
   }
 
   updateAclLevel(member: ProjectAcl, rawLevel: string): void {
@@ -181,15 +177,13 @@ export class TeamComponent implements OnInit {
           });
         }),
       )
-      .subscribe({
-        next: (projectAcl) => {
-          if (projectAcl) {
-            const updated = this._team().map((m) =>
-              m.userId === member.userId ? { ...m, level: newLevel } : m,
-            );
-            this._team.set(updated);
-          }
-        },
+      .subscribe((projectAcl) => {
+        if (projectAcl) {
+          const updated = this._team().map((m) =>
+            m.userId === member.userId ? { ...m, level: newLevel } : m,
+          );
+          this._team.set(updated);
+        }
       });
   }
 

--- a/indigo-frontend/src/core/components/common/team/team.component.ts
+++ b/indigo-frontend/src/core/components/common/team/team.component.ts
@@ -1,12 +1,12 @@
 import {
   Component,
+  computed,
+  inject,
   Input,
   OnInit,
-  inject,
   signal,
-  computed,
-  WritableSignal,
   ViewChild,
+  WritableSignal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CardComponent } from '../card/card.component';
@@ -31,6 +31,7 @@ import { NgSelectComponent, NgSelectModule } from '@ng-select/ng-select';
 import { FormsModule } from '@angular/forms';
 import { TeamComponentConfig } from './team.config';
 import { InitialsPipe } from '../../../pipes/avatars.pipe';
+
 type UserSuggestionWithState = UserSuggestion & { added?: boolean };
 
 interface TeamLoadingState {
@@ -112,7 +113,6 @@ export class TeamComponent implements OnInit {
           this.userSuggestions = list;
           this.rebuildSuggestionsState();
         },
-        error: (err) => console.error('Failed to load suggestions', err),
       });
   }
 
@@ -152,9 +152,6 @@ export class TeamComponent implements OnInit {
       )
       .subscribe({
         next: () => this.handleSuccessfulUserAddition(),
-        error: (err) => {
-          console.error('Failed to update ACL with new users:', err);
-        },
       });
   }
 
@@ -192,9 +189,6 @@ export class TeamComponent implements OnInit {
             );
             this._team.set(updated);
           }
-        },
-        error: (err) => {
-          console.error('Failed to update ACL level:', err);
         },
       });
   }

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/starred-experiments/starred-experiments.component.ts
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/starred-experiments/starred-experiments.component.ts
@@ -4,7 +4,7 @@ import { CardComponent } from '@/core/components/common/card/card.component';
 import { BadgeComponent } from '@/core/components/common/badge/badge.component';
 import { ApiService } from '@/core/services/api.service';
 import { NormalizeLabelPipe } from '@/core/pipes/normalizeLabe.pipe';
-import { catchError, of, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { ExperimentStatus } from '@/core/enums/experiment-status.enum';
 import { ExperimentDetail } from '@/core/types/entities/experiments/experiment-detail.i';
 import {
@@ -39,14 +39,6 @@ export class StarredExperimentsComponent implements OnInit, OnDestroy {
     this.loading = true;
     this.service
       .request<ExperimentDetail[]>('get', 'experiments/marked')
-      .pipe(
-        catchError((err) => {
-          console.error('Failed to load marked experiments:', err);
-          this.error = 'Failed to load starred experiments';
-          this.loading = false;
-          return of(null);
-        }),
-      )
       .subscribe({
         next: (resp) => {
           this.experiments = Array.isArray(resp) ? resp : [];

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/starred-experiments/starred-experiments.component.ts
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/starred-experiments/starred-experiments.component.ts
@@ -4,7 +4,7 @@ import { CardComponent } from '@/core/components/common/card/card.component';
 import { BadgeComponent } from '@/core/components/common/badge/badge.component';
 import { ApiService } from '@/core/services/api.service';
 import { NormalizeLabelPipe } from '@/core/pipes/normalizeLabe.pipe';
-import { Subject } from 'rxjs';
+import { finalize, Subject, tap } from 'rxjs';
 import { ExperimentStatus } from '@/core/enums/experiment-status.enum';
 import { ExperimentDetail } from '@/core/types/entities/experiments/experiment-detail.i';
 import {
@@ -39,18 +39,15 @@ export class StarredExperimentsComponent implements OnInit, OnDestroy {
     this.loading = true;
     this.service
       .request<ExperimentDetail[]>('get', 'experiments/marked')
-      .subscribe({
-        next: (resp) => {
-          this.experiments = Array.isArray(resp) ? resp : [];
-        },
-        error: (err) => {
-          console.error('Failed to load marked experiments:', err);
-          this.error = 'Failed to load starred experiments';
-        },
-        complete: () => {
-          this.loading = false;
-        },
-      });
+      .pipe(
+        tap({
+          error: () => (this.error = 'Failed to load starred experiments'),
+        }),
+        finalize(() => (this.loading = false)),
+      )
+      .subscribe(
+        (resp) => (this.experiments = Array.isArray(resp) ? resp : []),
+      );
   }
 
   ngOnDestroy(): void {

--- a/indigo-frontend/src/core/services/error-handler.ts
+++ b/indigo-frontend/src/core/services/error-handler.ts
@@ -33,6 +33,9 @@ export class ELNErrorHandler implements ErrorHandler {
       }
       return ['Server error. Please try again later', commonLogMessage];
     }
+    if (error instanceof Error && error.message != null) {
+      return [error.message, error.message]
+    }
     return ['Unknown error', 'Unknown error'];
   }
 }

--- a/indigo-frontend/src/core/services/error-handler.ts
+++ b/indigo-frontend/src/core/services/error-handler.ts
@@ -1,0 +1,38 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { BackendError } from '@core/types/entities/base-entity.i';
+import { NotificationType } from '@core/types/notification.i';
+import { ErrorHandler, inject } from '@angular/core';
+import { NotificationService } from '@core/services/notification/notification.service';
+
+export class ELNErrorHandler implements ErrorHandler {
+  notificationService = inject(NotificationService);
+
+  handleError(error: unknown): void {
+    try {
+      const [message, log]: [string, string] = this.detectMessage(error);
+      console.error(log, error);
+      this.notificationService.notify({
+        message,
+        type: NotificationType.Error,
+        isInline: false,
+      });
+    } catch (e) {
+      console.error('Error handling error', e, error);
+    }
+  }
+
+  private detectMessage(error: unknown): [string, string] {
+    if (error instanceof HttpErrorResponse) {
+      const commonLogMessage = `Server error calling ${error.url}: ${error.status} ${error.statusText}`;
+      if (Array.isArray(error.error)) {
+        const array: BackendError[] = error.error;
+        const message = array
+          .map((x) => (x.path ? `${x.path}: ${x.message}` : x.message))
+          .join('\n');
+        return [message, `${commonLogMessage}: ${message}`];
+      }
+      return ['Server error. Please try again later', commonLogMessage];
+    }
+    return ['Unknown error', 'Unknown error'];
+  }
+}

--- a/indigo-frontend/src/core/services/experiment/experiment-detail.service.ts
+++ b/indigo-frontend/src/core/services/experiment/experiment-detail.service.ts
@@ -3,7 +3,7 @@ import { ApiService } from '@/core/services/api.service';
 import { ExperimentDetail } from '@core/types/entities/experiments/experiment-detail.i';
 import { ExperimentModel } from '@core/types/entities/experiments/experiment.i';
 import { Mutation } from '@core/types/entities/experiments/mutation.i';
-import { Observable, tap } from 'rxjs';
+import { finalize, Observable, tap } from 'rxjs';
 
 @Injectable()
 export class ExperimentDetailService {
@@ -27,16 +27,15 @@ export class ExperimentDetailService {
 
     this.service
       .request<ExperimentDetail>('get', `experiments/${id}`)
-      .subscribe({
-        next: (exp) => {
-          this.experimentDetail.set(exp);
-          this.experimentModel.set(exp.model);
-          this.isLoading.set(false);
-        },
-        error: () => {
-          this.hasError.set(true);
-          this.isLoading.set(false);
-        },
+      .pipe(
+        tap({
+          error: () => this.hasError.set(true),
+        }),
+        finalize(() => this.isLoading.set(false)),
+      )
+      .subscribe((exp) => {
+        this.experimentDetail.set(exp);
+        this.experimentModel.set(exp.model);
       });
   }
 
@@ -75,7 +74,7 @@ export class ExperimentDetailService {
             this.experimentModel.set(updatedModel);
             this.isLoading.set(false);
           },
-          error: (error) => {
+          error: () => {
             this.hasError.set(true);
             this.isLoading.set(false);
           },

--- a/indigo-frontend/src/core/services/experiment/experiment-detail.service.ts
+++ b/indigo-frontend/src/core/services/experiment/experiment-detail.service.ts
@@ -76,7 +76,6 @@ export class ExperimentDetailService {
             this.isLoading.set(false);
           },
           error: (error) => {
-            console.error('Error updating experiment model:', error);
             this.hasError.set(true);
             this.isLoading.set(false);
           },

--- a/indigo-frontend/src/core/services/experiment/experiment-image.service.ts
+++ b/indigo-frontend/src/core/services/experiment/experiment-image.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { ApiService } from '@/core/services/api.service';
-import { catchError, of } from 'rxjs';
+import { finalize, tap } from 'rxjs';
 
 @Injectable()
 export class ExperimentImageService {
@@ -26,23 +26,17 @@ export class ExperimentImageService {
         responseType: 'blob',
       })
       .pipe(
-        catchError((err) => {
-          this.hasError.set(true);
-          this.isLoading.set(false);
-          return of(null);
+        tap({
+          error: () => this.hasError.set(true),
         }),
+        finalize(() => this.isLoading.set(false)),
       )
       .subscribe((blob) => {
-        this.isLoading.set(false);
-        if (blob) {
-          // Limpiar URL anterior si existe
-          const currentUrl = this.imageUrl();
-          if (currentUrl) {
-            URL.revokeObjectURL(currentUrl);
-          }
-          // Crear nueva URL desde el Blob
-          this.imageUrl.set(URL.createObjectURL(blob));
+        const currentUrl = this.imageUrl();
+        if (currentUrl) {
+          URL.revokeObjectURL(currentUrl);
         }
+        this.imageUrl.set(URL.createObjectURL(blob));
       });
   }
 

--- a/indigo-frontend/src/core/services/experiment/experiment-image.service.ts
+++ b/indigo-frontend/src/core/services/experiment/experiment-image.service.ts
@@ -27,7 +27,6 @@ export class ExperimentImageService {
       })
       .pipe(
         catchError((err) => {
-          console.error('Failed to load experiment picture:', err);
           this.hasError.set(true);
           this.isLoading.set(false);
           return of(null);

--- a/indigo-frontend/src/core/services/experiment/experiment.service.ts
+++ b/indigo-frontend/src/core/services/experiment/experiment.service.ts
@@ -1,7 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { ApiService } from '@/core/services/api.service';
-import { BehaviorSubject, filter, map, of, switchMap } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { BehaviorSubject, filter, map, switchMap, tap } from 'rxjs';
 import { LoadingState } from '@core/types/entities/loading-state.i';
 import { Template } from '@core/types/entities/template.i';
 import { ExperimentModel } from '@core/types/entities/experiments/experiment.i';
@@ -65,20 +64,19 @@ export class ExperimentService {
             .request<ExperimentModel>('get', `experiments/${id}/datamodel`)
             .pipe(map((model) => ({ experiment, template, model }))),
         ),
-        catchError(() => {
-          this.experimentSubject.next({ state: 'error' });
-          this.template.next({ state: 'error' });
-          this.model.next({ state: 'error' });
-          return of(null);
+        tap({
+          error: () => {
+            this.experimentSubject.next({ state: 'error' });
+            this.template.next({ state: 'error' });
+            this.model.next({ state: 'error' });
+          },
         }),
       )
       .subscribe((data) => {
-        if (data != null) {
-          const { experiment, template, model } = data;
-          this.experimentSubject.next({ state: 'ready', value: experiment });
-          this.template.next({ state: 'ready', value: template });
-          this.model.next({ state: 'ready', value: model });
-        }
+        const { experiment, template, model } = data;
+        this.experimentSubject.next({ state: 'ready', value: experiment });
+        this.template.next({ state: 'ready', value: template });
+        this.model.next({ state: 'ready', value: model });
       });
   }
 
@@ -89,15 +87,14 @@ export class ExperimentService {
         responseType: 'blob',
       })
       .pipe(
-        catchError(() => {
-          this.picture.next({ state: 'error' });
-          return of(null);
+        tap({
+          error: () => {
+            this.picture.next({ state: 'error' });
+          },
         }),
       )
       .subscribe((data) => {
-        if (data != null) {
-          this.picture.next({ state: 'ready', value: data });
-        }
+        this.picture.next({ state: 'ready', value: data });
       });
   }
 
@@ -119,9 +116,7 @@ export class ExperimentService {
       )
       .subscribe((newModel) => {
         this.mutating.next(false);
-        if (newModel != null) {
-          this.model.next({ state: 'ready', value: newModel });
-        }
+        this.model.next({ state: 'ready', value: newModel });
       });
   }
 }

--- a/indigo-frontend/src/core/services/experiment/experiment.service.ts
+++ b/indigo-frontend/src/core/services/experiment/experiment.service.ts
@@ -16,7 +16,9 @@ export class ExperimentService {
 
   // TODO using some hand-made LoadingState instead of separate data/loading/error to avoid inconsistent states;
   // if it's more readable to use separate flags or there is a better alternative, i'll rewrite it
-  private experimentSubject = new BehaviorSubject<LoadingState<ExperimentDetail>>({
+  private experimentSubject = new BehaviorSubject<
+    LoadingState<ExperimentDetail>
+  >({
     state: 'empty',
   });
   public experimentLoad$ = this.experimentSubject.asObservable();
@@ -63,8 +65,7 @@ export class ExperimentService {
             .request<ExperimentModel>('get', `experiments/${id}/datamodel`)
             .pipe(map((model) => ({ experiment, template, model }))),
         ),
-        catchError((err) => {
-          console.error('Failed to load experiment:', err);
+        catchError(() => {
           this.experimentSubject.next({ state: 'error' });
           this.template.next({ state: 'error' });
           this.model.next({ state: 'error' });
@@ -88,8 +89,7 @@ export class ExperimentService {
         responseType: 'blob',
       })
       .pipe(
-        catchError((err) => {
-          console.error('Failed to load experiment picture:', err);
+        catchError(() => {
           this.picture.next({ state: 'error' });
           return of(null);
         }),
@@ -116,13 +116,6 @@ export class ExperimentService {
         'post',
         `experiments/${this.experimentSubject.value.value.id}/datamodel`,
         { model: this.model.value.value, mutation },
-      )
-      .pipe(
-        catchError((err) => {
-          console.error('Failed to mutate experiment model:', err);
-          alert('Failed to mutate experiment model: ' + err);
-          return of(null);
-        }),
       )
       .subscribe((newModel) => {
         this.mutating.next(false);

--- a/indigo-frontend/src/core/services/health-hazards/built-in-dictionary.service.ts
+++ b/indigo-frontend/src/core/services/health-hazards/built-in-dictionary.service.ts
@@ -1,7 +1,10 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { Observable, tap } from 'rxjs';
 import { ApiService } from '@/core/services/api.service';
-import { DictionaryItemRef, BuiltInDictionary } from '@/core/types/entities/dictionary.i';
+import {
+  BuiltInDictionary,
+  DictionaryItemRef,
+} from '@/core/types/entities/dictionary.i';
 
 @Injectable({
   providedIn: 'root',
@@ -10,7 +13,9 @@ export class BuiltInDictionaryService {
   private service = inject(ApiService);
 
   // Signals for dictionary state - keyed by dictionary type
-  readonly dictionaries = signal<Map<BuiltInDictionary, DictionaryItemRef[]>>(new Map());
+  readonly dictionaries = signal<Map<BuiltInDictionary, DictionaryItemRef[]>>(
+    new Map(),
+  );
   readonly isLoading = signal<Map<BuiltInDictionary, boolean>>(new Map());
   readonly hasError = signal<Map<BuiltInDictionary, boolean>>(new Map());
 
@@ -27,11 +32,7 @@ export class BuiltInDictionaryService {
           this.setDictionary(dictionary, items);
           this.setLoading(dictionary, false);
         },
-        error: (error) => {
-          console.warn(
-            `Error loading dictionary ${dictionary}:`,
-            error,
-          );
+        error: () => {
           this.setDictionary(dictionary, []);
           this.setError(dictionary, true);
           this.setLoading(dictionary, false);
@@ -40,7 +41,9 @@ export class BuiltInDictionaryService {
   }
 
   // Getter methods
-  getDictionary(dictionary: BuiltInDictionary): Observable<DictionaryItemRef[]> {
+  getDictionary(
+    dictionary: BuiltInDictionary,
+  ): Observable<DictionaryItemRef[]> {
     // Return observable from the dictionary endpoint
     return this.service
       .request<DictionaryItemRef[]>('get', `dictionaries/${dictionary}`)
@@ -50,8 +53,7 @@ export class BuiltInDictionaryService {
             this.setDictionary(dictionary, items);
             this.setLoading(dictionary, false);
           },
-          error: (error) => {
-            console.error(`Error fetching dictionary ${dictionary}:`, error);
+          error: () => {
             this.setError(dictionary, true);
             this.setLoading(dictionary, false);
           },

--- a/indigo-frontend/src/core/services/health-hazards/built-in-dictionary.service.ts
+++ b/indigo-frontend/src/core/services/health-hazards/built-in-dictionary.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
-import { Observable, tap } from 'rxjs';
+import { finalize, Observable, tap } from 'rxjs';
 import { ApiService } from '@/core/services/api.service';
 import {
   BuiltInDictionary,
@@ -27,17 +27,16 @@ export class BuiltInDictionaryService {
 
     this.service
       .request<DictionaryItemRef[]>('get', `dictionaries/${dictionary}`)
-      .subscribe({
-        next: (items) => {
-          this.setDictionary(dictionary, items);
-          this.setLoading(dictionary, false);
-        },
-        error: () => {
-          this.setDictionary(dictionary, []);
-          this.setError(dictionary, true);
-          this.setLoading(dictionary, false);
-        },
-      });
+      .pipe(
+        tap({
+          error: () => {
+            this.setDictionary(dictionary, []);
+            this.setError(dictionary, true);
+          },
+        }),
+        finalize(() => this.setLoading(dictionary, false)),
+      )
+      .subscribe((items) => this.setDictionary(dictionary, items));
   }
 
   // Getter methods
@@ -51,13 +50,12 @@ export class BuiltInDictionaryService {
         tap({
           next: (items) => {
             this.setDictionary(dictionary, items);
-            this.setLoading(dictionary, false);
           },
           error: () => {
             this.setError(dictionary, true);
-            this.setLoading(dictionary, false);
           },
         }),
+        finalize(() => this.setLoading(dictionary, false)),
       );
   }
 

--- a/indigo-frontend/src/core/services/notebook/notebook.service.ts
+++ b/indigo-frontend/src/core/services/notebook/notebook.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, signal } from '@angular/core';
 import { NotebookDetail } from '@/core/types/entities/notebook-detail.i';
 import { ApiService } from '@/core/services/api.service';
+import { finalize, tap } from 'rxjs';
 
 @Injectable()
 export class NotebookService {
@@ -13,25 +14,32 @@ export class NotebookService {
   private readonly currentId = signal<string | null>(null);
 
   // Public API
-  setNotebook(notebookDetail: NotebookDetail | null) { this.notebook.set(notebookDetail); }
-  setLoading(value: boolean) { this.isLoading.set(value); }
-  setError(value: boolean) { this.hasError.set(value); }
+  setNotebook(notebookDetail: NotebookDetail | null) {
+    this.notebook.set(notebookDetail);
+  }
+  setLoading(value: boolean) {
+    this.isLoading.set(value);
+  }
+  setError(value: boolean) {
+    this.hasError.set(value);
+  }
 
   load(id: string) {
     this.currentId.set(id);
     this.isLoading.set(true);
     this.hasError.set(false);
 
-    this.api.request<NotebookDetail>('get', `notebooks/${id}`).subscribe({
-      next: (nb) => {
+    this.api
+      .request<NotebookDetail>('get', `notebooks/${id}`)
+      .pipe(
+        tap({
+          error: () => this.isLoading.set(false),
+        }),
+        finalize(() => this.isLoading.set(false)),
+      )
+      .subscribe((nb) => {
         this.notebook.set(nb);
-        this.isLoading.set(false);
-      },
-      error: () => {
-        this.hasError.set(true);
-        this.isLoading.set(false);
-      },
-    });
+      });
   }
 
   refresh() {

--- a/indigo-frontend/src/core/services/notebook/notebook.service.ts
+++ b/indigo-frontend/src/core/services/notebook/notebook.service.ts
@@ -33,7 +33,7 @@ export class NotebookService {
       .request<NotebookDetail>('get', `notebooks/${id}`)
       .pipe(
         tap({
-          error: () => this.isLoading.set(false),
+          error: () => this.hasError.set(true),
         }),
         finalize(() => this.isLoading.set(false)),
       )

--- a/indigo-frontend/src/core/types/entities/base-entity.i.ts
+++ b/indigo-frontend/src/core/types/entities/base-entity.i.ts
@@ -11,3 +11,8 @@ export interface EdBy {
   username: string;
   displayName: string;
 }
+
+export interface BackendError {
+  path?: string;
+  message: string;
+}


### PR DESCRIPTION
- Created global error handler:
  - Takes error message(s) from response JSON; typically, they are more useful and has more details than generic message like "Cannot create project"
  - If JSON is not available (backend malfunctioned or network failed), it shows generic message; ideally we would detect some types of errors like network failures and provide more meaningful errors in this case
- All uncaught RxJS errors are processed by this handler; so in typical case no need to deal with errors at all
- If you need to provide custom handling _in addition to default toast notification_ (e.g. update component state), use `tap({error: ...})`
- If you need to provide custom handling _instead of default notificaiton_, just use standard `pipe(catchError(...))` or `subscribe({error: ...})`. If you don't rethrow error in your handler, it won't be processed by the default handler
- If we want to provide custom error message, use `catchError` and `throwError` with custom error message
- As a downside, we cannot provide default error message per use case (e.g. "Cannot create notebook" or "Cannot update project"); assuming backend will send meaningful error message so user won't get lost. However, if we want to highlight what kind of operation was failed, we likely need to add some pipe operation to every API call. Alternatively, we can add an optional argument to APIService methods

- As an alternative, we could use HTTP interceptor, but from what I understand it's less flexible and wouldn't allow to override error handling behavior per use case

- Unrelated, but I noticed several places where catchError was pushing `null` value downstream; subscribe then was checking for `null` value; I replaced some of these usages, separating next path from error path