### PR TITLE
feat(412): [FE] Implement add batch functionality

### DIFF
--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/product-batch-summary-table/product-batch-summary-table.component.html
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/product-batch-summary-table/product-batch-summary-table.component.html
@@ -1,9 +1,31 @@
 <div class="flex justify-between py-1">
   <h3 class="text-sm font-semibold p-3">Product Batch Summary</h3>
   <div class="flex justify-between items-center gap-3">
-    <eln-button (click)="addNewRow()" variant="grey">
+    <eln-button [matMenuTriggerFor]="addBatchMenu" variant="grey">
       <mat-icon class="text-md">add</mat-icon>
     </eln-button>
+    <mat-menu #addBatchMenu="matMenu" xPosition="before">
+      <button mat-menu-item (click)="addNewRow()">
+        <mat-icon>add</mat-icon>
+        <span>Add New Batch</span>
+      </button>
+      <button mat-menu-item [matMenuTriggerFor]="linkWithProductsMenu" [disabled]="!linkableProducts().length">
+        <mat-icon>link</mat-icon>
+        <span>Add Batch and Link with</span>
+      </button>
+    </mat-menu>
+    <mat-menu #linkWithProductsMenu="matMenu" xPosition="after">
+      @for (product of linkableProducts(); track product.anchor; let index = $index) {
+        <button mat-menu-item (click)="addBatchForOutput(product)">
+          <span>{{ getProductMenuLabel(product, index) }}</span>
+        </button>
+      }
+      @if (!linkableProducts().length) {
+        <button mat-menu-item disabled>
+          <span>No products available</span>
+        </button>
+      }
+    </mat-menu>
   </div>
 </div>
 <eln-editable-data-table

--- a/indigo-frontend/src/app/pages/experiment/stoichiometry/product-batch-summary-table/product-batch-summary-table.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/stoichiometry/product-batch-summary-table/product-batch-summary-table.component.ts
@@ -17,6 +17,7 @@ import { EnteredValue } from '@core/types/entities/values.i';
 import { determineCellClasses } from '@core/utils/experiment-model.util';
 import { ButtonComponent } from '@/core/components/common/button/button.component';
 import { MatIcon } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
 
 interface OutputSampleRow {
   output: ReactionOutput;
@@ -26,7 +27,7 @@ interface OutputSampleRow {
 @Component({
   selector: 'eln-product-batch-summary-table',
   templateUrl: './product-batch-summary-table.component.html',
-  imports: [MatSnackBarModule, EditableDataTableComponent, ButtonComponent, MatIcon],
+  imports: [MatSnackBarModule, EditableDataTableComponent, ButtonComponent, MatIcon, MatMenuModule],
 })
 export class ProductBatchSummaryTableComponent {
   private experimentDetailService = inject(ExperimentDetailService);
@@ -43,6 +44,8 @@ export class ProductBatchSummaryTableComponent {
     const outputs = this.reaction()?.outputs;
     return outputs?.flatMap((output) => output.samples.map((sample) => ({ output, sample })));
   });
+
+  linkableProducts = computed(() => this.reaction()?.outputs ?? []);
 
   readonly columns = computed<ColumnConfig<OutputSampleRow>[]>(() => [
     {
@@ -246,10 +249,26 @@ export class ProductBatchSummaryTableComponent {
     return determineCellClasses(value, this.experimentDetailService.updatedNodes());
   }
 
+  getProductMenuLabel(output: ReactionOutput, index: number): string {
+    return output.outputName?.trim() || output.chemicalName?.trim() || `P${index + 1}`;
+  }
+
+  addBatchForOutput(output: ReactionOutput) {
+    this.experimentDetailService
+      .updateDataModel({
+        type: 'AddProductSample',
+        anchor: output.anchor,
+      })
+      .subscribe({});
+  }
+
   addNewRow() {
-    // TODO: Implement mutation for adding new output sample row
-    this.snackBar.open('Add row functionality not yet implemented', 'Close', {
-      duration: 3000,
-    });
+    this.snackBar.open(
+      'Add New Batch still needs a backend mutation to create an unlinked side product batch.',
+      'Close',
+      {
+        duration: 4000,
+      },
+    );
   }
 }


### PR DESCRIPTION
## Description:

- Reworks the Add Batch entry point into a clearer menu-based flow with separate paths for linked and unlinked batch creation.
- Adds the linked batch flow so users can create a new batch directly from an existing reaction product.
- Populates the linked option dynamically from the available products and handles the no-products case gracefully.
- Keeps the linked scenario aligned with the backend behavior that already exists today.
- Leaves the Add New Batch path intentionally guarded until backend support for creating an empty output / side product is confirmed.
- Preserves the current Product Batch Summary behavior while making the add flow closer to the intended UX.

## Screenshots

<img width="1645" height="619" alt="image" src="https://github.com/user-attachments/assets/46b6ec72-be01-4ac1-a354-219bd0ef48bc" />
