### PR TITLE
ELN-202: Manage Experiment members

### DIFF
--- a/indigo-frontend/src/app/pages/experiment/experiment-actions/experiment-actions.component.html
+++ b/indigo-frontend/src/app/pages/experiment/experiment-actions/experiment-actions.component.html
@@ -14,6 +14,12 @@
 
     <div class="flex-1"></div>
 
+    <eln-member-avatars
+      [members]="experiment().acl ?? []"
+      [totalCount]="experiment().acl?.length ?? 0"
+      [maxVisible]="3"
+    />
+
     <eln-button
       variant="grey-outline"
       classList="!rounded-lg border border-neutral-400 text-primary-400"

--- a/indigo-frontend/src/app/pages/experiment/experiment-actions/experiment-actions.component.html
+++ b/indigo-frontend/src/app/pages/experiment/experiment-actions/experiment-actions.component.html
@@ -14,6 +14,14 @@
 
     <div class="flex-1"></div>
 
+    <eln-button
+      variant="grey-outline"
+      classList="!rounded-lg border border-neutral-400 text-primary-400"
+      (click)="openAddMemberDrawer()"
+    >
+      <eln-svg icon="user-add" />
+    </eln-button>
+
     @for (button of BUTTONS; track button.action) {
       @if (
         !button.inDetailsMenu &&

--- a/indigo-frontend/src/app/pages/experiment/experiment-actions/experiment-actions.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/experiment-actions/experiment-actions.component.ts
@@ -18,6 +18,7 @@ import { SlideInPanelService } from '@core/components/common/slide-in-panel/slid
 import { ExperimentTeamDrawerComponent } from '@pages/experiment/experiment-team-drawer/experiment-team-drawer.component';
 import { SvgIconComponent } from '@core/components/common/svg-icon/svg-icon.component';
 import { ButtonComponent } from '@core/components/common/button/button.component';
+import { MemberAvatarsComponent } from '@core/components/common/member-avatars/member-avatars.component';
 
 enum Action {
   COMPLETE = 'COMPLETE',
@@ -116,6 +117,7 @@ const BUTTONS: ActionButton[] = [
     NormalizeLabelPipe,
     SvgIconComponent,
     ButtonComponent,
+    MemberAvatarsComponent,
   ],
   templateUrl: './experiment-actions.component.html',
 })

--- a/indigo-frontend/src/app/pages/experiment/experiment-actions/experiment-actions.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/experiment-actions/experiment-actions.component.ts
@@ -14,6 +14,10 @@ import { DownloadService } from '@core/services/download.service';
 import { BadgeComponent } from '@core/components/common/badge/badge.component';
 import { NormalizeLabelPipe } from '@core/pipes/normalizeLabe.pipe';
 import { EXPERIMENT_STATUS_DECORATION_MAP } from '@core/utils/experiment-status.util';
+import { SlideInPanelService } from '@core/components/common/slide-in-panel/slide-in-panel.service';
+import { ExperimentTeamDrawerComponent } from '@pages/experiment/experiment-team-drawer/experiment-team-drawer.component';
+import { SvgIconComponent } from '@core/components/common/svg-icon/svg-icon.component';
+import { ButtonComponent } from '@core/components/common/button/button.component';
 
 enum Action {
   COMPLETE = 'COMPLETE',
@@ -103,7 +107,16 @@ const BUTTONS: ActionButton[] = [
 @Component({
   selector: 'eln-experiment-actions',
   standalone: true,
-  imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, BadgeComponent, NormalizeLabelPipe],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    MatMenuModule,
+    BadgeComponent,
+    NormalizeLabelPipe,
+    SvgIconComponent,
+    ButtonComponent,
+  ],
   templateUrl: './experiment-actions.component.html',
 })
 export class ExperimentActionsComponent {
@@ -111,6 +124,7 @@ export class ExperimentActionsComponent {
   downloadService = inject(DownloadService);
   notificationService = inject(NotificationService);
   dialog = inject(MatDialog);
+  slideInPanelService = inject(SlideInPanelService);
 
   experiment = computed(() => this.experimentDetailService.experimentDetail());
 
@@ -183,6 +197,17 @@ export class ExperimentActionsComponent {
           onConfirmed(templateId);
         }
       });
+  }
+
+  openAddMemberDrawer(): void {
+    const experimentId = this.experiment()?.id;
+    if (!experimentId) return;
+
+    this.slideInPanelService.open(ExperimentTeamDrawerComponent, {
+      inputs: {
+        experimentId: experimentId,
+      },
+    });
   }
 
   protected readonly statusDecorMap = EXPERIMENT_STATUS_DECORATION_MAP;

--- a/indigo-frontend/src/app/pages/experiment/experiment-item/experiment-item.component.html
+++ b/indigo-frontend/src/app/pages/experiment/experiment-item/experiment-item.component.html
@@ -8,24 +8,11 @@
 
       <div class="flex items-center gap-x-3">
         @if (variant === 'grid') {
-          <div class="flex -space-x-2">
-            @for (user of experiment.acl; track user.username) {
-              <div
-                class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-[#e0e0e0] text-[#646464] text-[0.625rem] font-semibold uppercase border border-white"
-                [matTooltip]="user.displayName"
-                matTooltipPosition="above"
-              >
-                {{ user.displayName | initials }}
-              </div>
-            }
-            @if ((experiment.acl?.length ?? 0) > 3) {
-              <span
-                class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-primary-400 text-white text-[0.75rem]"
-              >
-                +{{ (experiment.acl?.length ?? 0) - 3 }}
-              </span>
-            }
-          </div>
+          <eln-member-avatars
+            [members]="experiment.acl ?? []"
+            [totalCount]="experiment.acl?.length ?? 0"
+            [maxVisible]="3"
+          />
         }
 
         <button
@@ -92,24 +79,11 @@
         <div class="flex flex-col" [ngClass]="{ 'flex-col space-y-2': variant == 'list' }" *ngIf="variant === 'list'">
           <div class="text-neutral-1000 text-sm">Members</div>
           <div class="flex items-center">
-            <div class="flex -space-x-2">
-              @for (user of experiment.acl; track user.username) {
-                <div
-                  class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-[#e0e0e0] text-[#646464] text-[0.625rem] font-semibold uppercase border border-white"
-                  [matTooltip]="user.displayName ?? user.username"
-                  matTooltipPosition="above"
-                >
-                  {{ user.displayName ?? user.username | initials }}
-                </div>
-              }
-              @if ((experiment.acl?.length ?? 0) > 3) {
-                <span
-                  class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-primary-400 text-white text-[0.75rem]"
-                >
-                  +{{ (experiment.acl?.length ?? 0) - 3 }}
-                </span>
-              }
-            </div>
+            <eln-member-avatars
+              [members]="experiment.acl ?? []"
+              [totalCount]="experiment.acl?.length ?? 0"
+              [maxVisible]="3"
+            />
           </div>
         </div>
 

--- a/indigo-frontend/src/app/pages/experiment/experiment-item/experiment-item.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/experiment-item/experiment-item.component.ts
@@ -7,13 +7,13 @@ import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatTooltip } from '@angular/material/tooltip';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { NormalizeLabelPipe } from '@/core/pipes/normalizeLabe.pipe';
-import { InitialsPipe } from '@/core/pipes/avatars.pipe';
 import { getExperimentStatusBadgeVariant } from '@/core/utils/experiment-status.util';
 import { SvgIconComponent } from '@/core/components/common/svg-icon/svg-icon.component';
 import { ExperimentDetailService } from '@/core/services/experiment/experiment-detail.service';
 import { ApiImageComponent } from '@core/components/common/image/api-image.component';
+import { MemberAvatarsComponent } from '@core/components/common/member-avatars/member-avatars.component';
 
 @Component({
   selector: 'eln-experiment-item',
@@ -24,12 +24,12 @@ import { ApiImageComponent } from '@core/components/common/image/api-image.compo
     MatButtonModule,
     MatIconModule,
     MatMenuModule,
+    MatTooltipModule,
     BadgeComponent,
     NormalizeLabelPipe,
-    InitialsPipe,
-    MatTooltip,
     SvgIconComponent,
     ApiImageComponent,
+    MemberAvatarsComponent,
   ],
   templateUrl: './experiment-item.component.html',
 })

--- a/indigo-frontend/src/app/pages/experiment/experiment-team-drawer/experiment-team-drawer.component.html
+++ b/indigo-frontend/src/app/pages/experiment/experiment-team-drawer/experiment-team-drawer.component.html
@@ -1,0 +1,32 @@
+<div class="flex flex-col h-full bg-white">
+  <!-- Header -->
+  <div class="flex items-center justify-between p-4 border-b border-neutral-200">
+    <div class="flex items-center gap-2">
+      <h2 class="text-lg font-semibold text-neutral-1000">Add Team Member</h2>
+      @if (experiment()) {
+        <eln-counter [count]="(experiment().acl || []).length" variant="grey" size="large" />
+      }
+    </div>
+    <button
+      type="button"
+      class="flex items-center justify-center w-8 h-8 rounded-full hover:bg-neutral-100 transition-colors"
+      (click)="onClose()"
+      aria-label="Close"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+
+  <!-- Content -->
+  <div class="flex-1 overflow-y-auto p-4 [&_eln-card>div]:!border-0 [&_eln-card>div]:!p-0">
+    @if (experiment()) {
+      <eln-team
+        [entityId]="experiment().id"
+        [team]="experiment().acl || []"
+        [config]="teamConfig"
+        [showHeader]="false"
+        (teamChanged)="onTeamChanged($event)"
+      />
+    }
+  </div>
+</div>

--- a/indigo-frontend/src/app/pages/experiment/experiment-team-drawer/experiment-team-drawer.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/experiment-team-drawer/experiment-team-drawer.component.ts
@@ -1,0 +1,42 @@
+import { Component, computed, inject, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TeamComponent } from '@core/components/common/team/team.component';
+import { TeamComponentConfig } from '@core/components/common/team/team.config';
+import { SlideInPanelService } from '@core/components/common/slide-in-panel/slide-in-panel.service';
+import { ExperimentDetailService } from '@core/services/experiment/experiment-detail.service';
+import { MatIconModule } from '@angular/material/icon';
+import { CounterComponent } from '@core/components/common/counter/counter.component';
+import { ACLEntry } from '@core/types/entities/acl.i';
+
+@Component({
+  selector: 'eln-experiment-team-drawer',
+  standalone: true,
+  imports: [CommonModule, TeamComponent, MatIconModule, CounterComponent],
+  templateUrl: './experiment-team-drawer.component.html',
+})
+export class ExperimentTeamDrawerComponent {
+  experimentId = input.required<string>();
+
+  private slideInPanelService = inject(SlideInPanelService);
+  private experimentDetailService = inject(ExperimentDetailService);
+
+  experiment = computed(() => this.experimentDetailService.experimentDetail());
+
+  teamConfig: TeamComponentConfig = {
+    buildAccessEndpoint: (id: string) => `experiments/${id}/access`,
+  };
+
+  onClose(): void {
+    this.slideInPanelService.close();
+  }
+
+  onTeamChanged(updatedTeam: ACLEntry[]): void {
+    const currentExperiment = this.experimentDetailService.experimentDetail();
+    if (currentExperiment) {
+      this.experimentDetailService.experimentDetail.set({
+        ...currentExperiment,
+        acl: updatedTeam,
+      });
+    }
+  }
+}

--- a/indigo-frontend/src/app/pages/notebook/notebook-item/notebook-item.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-item/notebook-item.component.html
@@ -8,24 +8,7 @@
 
       <div class="flex items-center gap-x-3">
         @if (variant === 'grid') {
-          <div class="flex -space-x-2">
-            @for (user of notebook.acl; track user.username) {
-              <div
-                class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-[#e0e0e0] text-[#646464] text-[0.625rem] font-semibold uppercase border border-white"
-                [matTooltip]="user.displayName"
-                matTooltipPosition="above"
-              >
-                {{ user.displayName | initials }}
-              </div>
-            }
-            @if (notebook.aclCount > 3) {
-              <span
-                class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-primary-400 text-white text-[0.75rem]"
-              >
-                +{{ notebook.aclCount - 3 }}
-              </span>
-            }
-          </div>
+          <eln-member-avatars [members]="notebook.acl ?? []" [totalCount]="notebook.aclCount ?? 0" [maxVisible]="3" />
         }
 
         <div class="relative -right-1">
@@ -72,24 +55,7 @@
         <div class="flex flex-col" [ngClass]="{ 'flex-col space-y-2': variant == 'list' }" *ngIf="variant === 'list'">
           <div class="text-neutral-1000 text-sm">Members</div>
           <div class="flex items-center">
-            <div class="flex -space-x-2">
-              @for (user of notebook.acl; track user.username) {
-                <div
-                  class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-[#e0e0e0] text-[#646464] text-[0.625rem] font-semibold uppercase border border-white"
-                  [matTooltip]="user.displayName"
-                  matTooltipPosition="above"
-                >
-                  {{ user.displayName | initials }}
-                </div>
-              }
-              @if (notebook.aclCount > 3) {
-                <span
-                  class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-primary-400 text-white text-[0.75rem]"
-                >
-                  +{{ notebook.aclCount - 3 }}
-                </span>
-              }
-            </div>
+            <eln-member-avatars [members]="notebook.acl ?? []" [totalCount]="notebook.aclCount ?? 0" [maxVisible]="3" />
           </div>
         </div>
 

--- a/indigo-frontend/src/app/pages/notebook/notebook-item/notebook-item.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-item/notebook-item.component.ts
@@ -6,13 +6,12 @@ import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
-import { InitialsPipe } from '../../../../core/pipes/avatars.pipe';
-import { MatTooltip } from '@angular/material/tooltip';
+import { MemberAvatarsComponent } from '@core/components/common/member-avatars/member-avatars.component';
 
 @Component({
   selector: 'eln-notebook-item',
   standalone: true,
-  imports: [CommonModule, CardComponent, MatButtonModule, MatIconModule, MatMenuModule, InitialsPipe, MatTooltip],
+  imports: [CommonModule, CardComponent, MatButtonModule, MatIconModule, MatMenuModule, MemberAvatarsComponent],
   templateUrl: './notebook-item.component.html',
 })
 export class NotebookItemComponent {

--- a/indigo-frontend/src/app/pages/project/project-item/project-item.component.html
+++ b/indigo-frontend/src/app/pages/project/project-item/project-item.component.html
@@ -8,24 +8,7 @@
 
       <div class="flex items-center gap-x-3">
         @if (variant === 'grid') {
-          <div class="flex -space-x-2">
-            @for (member of project.acl; track member) {
-              <div
-                class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-[#e0e0e0] text-[#646464] text-[0.625rem] font-semibold uppercase border border-white"
-                [matTooltip]="member.displayName ?? member.username"
-                matTooltipPosition="above"
-              >
-                {{ member.displayName ?? member.username | initials }}
-              </div>
-            }
-            @if (project.aclCount > 3) {
-              <span
-                class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-primary-400 text-white text-[0.75rem]"
-              >
-                +{{ project.aclCount - 3 }}
-              </span>
-            }
-          </div>
+          <eln-member-avatars [members]="project.acl" [totalCount]="project.aclCount" [maxVisible]="3" />
         }
 
         <div class="relative -right-1">
@@ -88,24 +71,7 @@
         <div class="flex flex-col" [ngClass]="{ 'flex-col space-y-2': variant == 'list' }" *ngIf="variant === 'list'">
           <div class="text-neutral-1000 text-sm">Members</div>
           <div class="flex items-center">
-            <div class="flex -space-x-2">
-              @for (member of project.acl; track member) {
-                <div
-                  class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-[#e0e0e0] text-[#646464] text-[0.625rem] font-semibold uppercase border border-white"
-                  [matTooltip]="member.displayName ?? member.username"
-                  matTooltipPosition="above"
-                >
-                  {{ member.displayName ?? member.username | initials }}
-                </div>
-              }
-              @if (project.aclCount > 3) {
-                <span
-                  class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-primary-400 text-white text-[0.75rem]"
-                >
-                  +{{ project.aclCount - 3 }}
-                </span>
-              }
-            </div>
+            <eln-member-avatars [members]="project.acl" [totalCount]="project.aclCount" [maxVisible]="3" />
           </div>
         </div>
 

--- a/indigo-frontend/src/app/pages/project/project-item/project-item.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-item/project-item.component.ts
@@ -6,8 +6,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { RouterLink } from '@angular/router';
 import { CardComponent } from '@core/components/common/card/card.component';
-import { InitialsPipe } from '@/core/pipes/avatars.pipe';
-import { MatTooltip } from '@angular/material/tooltip';
+import { MemberAvatarsComponent } from '@core/components/common/member-avatars/member-avatars.component';
 
 @Component({
   selector: 'eln-project-item',
@@ -19,30 +18,12 @@ import { MatTooltip } from '@angular/material/tooltip';
     MatIconModule,
     MatMenuModule,
     RouterLink,
-    InitialsPipe,
-    MatTooltip,
+    MemberAvatarsComponent,
   ],
   templateUrl: './project-item.component.html',
   styleUrls: ['./project-item.component.scss'],
 })
 export class ProjectItemComponent {
-  mock_users = [
-    'assets/avatar1.png',
-    'assets/avatar2.png',
-    'assets/avatar3.png',
-    '-',
-    '-',
-    '-',
-    '-',
-    '-',
-    '-',
-    '-',
-    '-',
-    '-',
-    '-',
-    '-',
-    '-',
-  ];
   @Input() project: Project;
   @Input() variant: 'grid' | 'list' = 'grid';
 }

--- a/indigo-frontend/src/core/components/common/member-avatars/member-avatars.component.html
+++ b/indigo-frontend/src/core/components/common/member-avatars/member-avatars.component.html
@@ -1,0 +1,18 @@
+<div class="flex -space-x-2">
+  @for (member of visibleMembers(); track member) {
+    <div
+      class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-[#e0e0e0] text-[#646464] text-[0.625rem] font-semibold uppercase border border-white"
+      [matTooltip]="member.displayName ?? member.username"
+      matTooltipPosition="above"
+    >
+      {{ member.displayName ?? member.username | initials }}
+    </div>
+  }
+  @if (totalCount() > maxVisible()) {
+    <span
+      class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-primary-400 text-white text-[0.75rem]"
+    >
+      +{{ totalCount() - maxVisible() }}
+    </span>
+  }
+</div>

--- a/indigo-frontend/src/core/components/common/member-avatars/member-avatars.component.scss
+++ b/indigo-frontend/src/core/components/common/member-avatars/member-avatars.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/indigo-frontend/src/core/components/common/member-avatars/member-avatars.component.ts
+++ b/indigo-frontend/src/core/components/common/member-avatars/member-avatars.component.ts
@@ -1,0 +1,22 @@
+import { Component, computed, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { InitialsPipe } from '@core/pipes/avatars.pipe';
+import { ACLEntry } from '@core/types/entities/acl.i';
+
+@Component({
+  selector: 'eln-member-avatars',
+  standalone: true,
+  imports: [CommonModule, MatTooltipModule, InitialsPipe],
+  templateUrl: './member-avatars.component.html',
+  styleUrls: ['./member-avatars.component.scss'],
+})
+export class MemberAvatarsComponent {
+  members = input<ACLEntry[]>([]);
+  totalCount = input<number>(0);
+  maxVisible = input<number>(3);
+
+  visibleMembers = computed(() => {
+    return this.members().slice(0, this.maxVisible());
+  });
+}

--- a/indigo-frontend/src/core/components/common/team/team.component.html
+++ b/indigo-frontend/src/core/components/common/team/team.component.html
@@ -1,10 +1,12 @@
 <eln-card classList="h-full">
-  <div class="flex items-center justify-between border-b border-b-neutral-200 pb-3">
-    <div class="flex items-center gap-2">
-      <h2 class="font-semibold text-base">Team</h2>
-      <eln-counter [count]="teamVm().length" variant="grey" size="large" />
+  @if (showHeader) {
+    <div class="flex items-center justify-between border-b border-b-neutral-200 pb-3">
+      <div class="flex items-center gap-2">
+        <h2 class="font-semibold text-base">Team</h2>
+        <eln-counter [count]="teamVm().length" variant="grey" size="large" />
+      </div>
     </div>
-  </div>
+  }
 
   <!-- Suggestions field -->
   <div class="flex items-center justify-between py-3 gap-2">
@@ -20,7 +22,7 @@
         [(ngModel)]="selectedUsers"
         (change)="onUsersSelected(selectedUsers)"
         [clearable]="true"
-        class="w-[300px]"
+        class="w-full"
       >
         <ng-template ng-option-tmp let-item="item" let-index="index">
           <div class="flex justify-between" [class.opacity-50]="item.added" [class.pointer-events-none]="item.added">
@@ -48,36 +50,36 @@
   </div>
 
   <!-- Team members list -->
-  <div class="space-y-2 py-3">
+  <div class="py-3 grid grid-cols-[auto_1fr_1fr_auto] gap-x-4 gap-y-2 items-center">
     @for (member of teamVm(); track member.username) {
       <div
-        class="grid grid-cols-[auto_1fr_1fr_auto] gap-4 items-center p-2 hover:bg-neutral-100 rounded-lg text-neutral-1000"
+        class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-[#e0e0e0] text-[#646464] text-[0.625rem] font-semibold uppercase border border-white"
       >
-        <div
-          class="flex items-center justify-center w-[1.6rem] h-[1.6rem] rounded-full bg-[#e0e0e0] text-[#646464] text-[0.625rem] font-semibold uppercase border border-white"
-        >
-          {{ member.displayName | initials }}
-        </div>
+        {{ member.displayName | initials }}
+      </div>
 
-        <p class="text-neutral-1000">{{ member.displayName }}</p>
+      <p class="text-neutral-1000 overflow-hidden text-ellipsis whitespace-nowrap">
+        {{ member.displayName }}
+      </p>
+      <div class="flex items-center gap-1">
         <p
-          class="text-neutral-800 overflow-hidden text-ellipsis whitespace-nowrap max-w-[148px] text-ellipsis"
+          class="text-neutral-800 overflow-hidden text-ellipsis whitespace-nowrap"
           [appTextOverflowTooltip]="member.username"
         >
           {{ member.username }}
         </p>
-        <div class="flex items-center gap-1 justify-self-end">
-          <eln-copy [text]="member.username" />
-          <eln-dropdown-menu
-            align="end"
-            class="[&_.dd-trigger]:pr-0 [&_.dd-trigger]:pl-2 [&_.dd-trigger]:text-primary-400 [&_.dd-container]:min-w-22"
-            [controlled]="true"
-            [selected]="member.level | normalizeLabel"
-            [items]="aclLevelOptions"
-            (itemSelected)="updateAclLevel(member, $event)"
-            [disabled]="member.disabled"
-          />
-        </div>
+        <eln-copy [text]="member.username" class="flex-shrink-0" />
+      </div>
+      <div class="flex items-center gap-1 justify-self-end">
+        <eln-dropdown-menu
+          align="end"
+          class="[&_.dd-trigger]:pr-0 [&_.dd-trigger]:pl-2 [&_.dd-trigger]:text-primary-400 [&_.dd-container]:min-w-22"
+          [controlled]="true"
+          [selected]="member.level | normalizeLabel"
+          [items]="aclLevelOptions"
+          (itemSelected)="updateAclLevel(member, $event)"
+          [disabled]="member.disabled"
+        />
       </div>
     }
   </div>

--- a/indigo-frontend/src/core/components/common/team/team.component.ts
+++ b/indigo-frontend/src/core/components/common/team/team.component.ts
@@ -1,4 +1,15 @@
-import { Component, computed, inject, Input, OnInit, signal, ViewChild, WritableSignal } from '@angular/core';
+import {
+  Component,
+  computed,
+  EventEmitter,
+  inject,
+  Input,
+  OnInit,
+  Output,
+  signal,
+  ViewChild,
+  WritableSignal,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CardComponent } from '../card/card.component';
 import { CopyComponent } from '../copy/copy.component';
@@ -53,6 +64,8 @@ export class TeamComponent implements OnInit {
   }
   private _team: WritableSignal<ACLEntry[]> = signal<ACLEntry[]>([]);
   @Input({ required: true }) config: TeamComponentConfig;
+  @Input() showHeader = true;
+  @Output() teamChanged = new EventEmitter<ACLEntry[]>();
 
   userSuggestions: UserRefWithState[] = [];
   selectedUsers: string[] = [];
@@ -151,6 +164,7 @@ export class TeamComponent implements OnInit {
         if (projectAcl) {
           const updated = this._team().map((m) => (m.username === member.username ? { ...m, level: newLevel } : m));
           this._team.set(updated);
+          this.teamChanged.emit(updated);
         }
       });
   }
@@ -186,8 +200,10 @@ export class TeamComponent implements OnInit {
         inherited: false,
       });
     });
-    this._team.set([...current, ...toAdd]);
+    const updatedTeam = [...current, ...toAdd];
+    this._team.set(updatedTeam);
     this.rebuildSuggestionsState();
     this.selectedUsers = [];
+    this.teamChanged.emit(updatedTeam);
   }
 }


### PR DESCRIPTION
## Overview

Added experiment member management functionality with a reusable member avatars component.

## What's New

- **Member Management Drawer**: Users can now add/remove members from experiments via a slide-in panel
- **Member Avatars Component**: Created reusable component to display member avatars consistently across the application
- **Add Member Button**: Added to experiment actions bar for quick access to member management

## Key Changes

1. **Created `MemberAvatarsComponent`**

   - Displays member initials in circular overlapping avatars
   - Shows "+X" badge for additional members
   - Used in project-item, experiment-item, notebook-item, and experiment-actions components
2. **Created `ExperimentTeamDrawerComponent`**

   - Slide-in drawer for managing experiment team members
   - Integrates with existing team management UI
3. **Enhanced `ExperimentActionsComponent`**

   - Added member avatars display
   - Added "Add Member" button with drawer integration
4. **Refactored Duplicate Code**

   - Removed ~100+ lines of duplicate avatar display code
   - Replaced with single reusable component across 4 locations