### PR TITLE
Small frontend fixes

### DIFF
--- a/indigo-frontend/src/app/app.config.ts
+++ b/indigo-frontend/src/app/app.config.ts
@@ -13,7 +13,7 @@ import { ApplicationConfig, importProvidersFrom, provideZoneChangeDetection } fr
 
 import { EditorFormlyFieldComponent } from '@/core/components/formly/fields/editor/editor-field.component';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withComponentInputBinding, withRouterConfig } from '@angular/router';
 import { FormlyModule } from '@ngx-formly/core';
 import { FormlyPresetModule } from '@ngx-formly/core/preset';
 import { FormlyMaterialModule } from '@ngx-formly/material';
@@ -92,7 +92,7 @@ export const appConfig: ApplicationConfig = {
       FormlyMatDatepickerModule,
     ),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes),
+    provideRouter(routes, withComponentInputBinding(), withRouterConfig({ paramsInheritanceStrategy: 'always' })),
     provideAnimationsAsync(),
     provideHttpClient(
       withXsrfConfiguration({

--- a/indigo-frontend/src/app/app.routes.ts
+++ b/indigo-frontend/src/app/app.routes.ts
@@ -23,7 +23,7 @@ export const routes: Routes = [
               import('@pages/project/project-list/project-list.component').then((c) => c.ProjectListComponent),
           },
           {
-            path: ':id',
+            path: ':projectId',
             loadComponent: () =>
               import('@pages/project/project-detail/project-detail.component').then((c) => c.ProjectDetailComponent),
             children: [

--- a/indigo-frontend/src/app/pages/experiment/experiment-add/experiment-add.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/experiment-add/experiment-add.component.ts
@@ -1,6 +1,5 @@
 import { FormDialogComponent } from '@/core/components/common/form-dialog/form-dialog.component';
 import { ApiService } from '@/core/services/api.service';
-import { NotebookService } from '@/core/services/notebook/notebook.service';
 import { ItemTemplate, RootTemplate } from '@/core/types/entities/template.i';
 import { CommonModule } from '@angular/common';
 import { Component, inject, OnInit } from '@angular/core';
@@ -31,7 +30,6 @@ interface ExperimentForm {
     MatProgressSpinnerModule,
   ],
   templateUrl: './experiment-add.component.html',
-  providers: [NotebookService],
 })
 export class ExperimentAddComponent implements OnInit {
   private api = inject(ApiService);

--- a/indigo-frontend/src/app/pages/experiment/experiment-layout/experiment-layout.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/experiment-layout/experiment-layout.component.ts
@@ -98,7 +98,6 @@ export class ExperimentLayoutComponent implements OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['experimentId']) {
-      this.experimentDetailService.reset();
       this.experimentDetailService.load(this.experimentId);
     }
   }

--- a/indigo-frontend/src/app/pages/experiment/experiment-layout/experiment-layout.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/experiment-layout/experiment-layout.component.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, effect, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, computed, effect, inject, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
-import { ActivatedRoute } from '@angular/router';
 
 import { BreadcrumbsComponent } from '@/core/components/breadcrumbs/breadcrumbs.component';
 import { CardComponent } from '@/core/components/common/card/card.component';
@@ -47,8 +46,8 @@ interface Tab {
     ReactionViewComponent,
   ],
 })
-export class ExperimentLayoutComponent implements OnInit, OnDestroy {
-  activatedRoute = inject(ActivatedRoute);
+export class ExperimentLayoutComponent implements OnChanges, OnDestroy {
+  @Input() experimentId!: string;
   experimentDetailService = inject(ExperimentDetailService);
   breadcrumbsState = inject(BreadcrumbsStateService);
 
@@ -97,9 +96,11 @@ export class ExperimentLayoutComponent implements OnInit, OnDestroy {
     }
   });
 
-  ngOnInit(): void {
-    const experimentId = this.activatedRoute.snapshot.params['experimentId'];
-    this.experimentDetailService.load(experimentId);
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['experimentId']) {
+      this.experimentDetailService.reset();
+      this.experimentDetailService.load(this.experimentId);
+    }
   }
 
   ngOnDestroy(): void {

--- a/indigo-frontend/src/app/pages/notebook/notebook-detail/notebook-detail.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-detail/notebook-detail.component.html
@@ -11,8 +11,8 @@
   </div>
 
   <div class="flex items-center mt-6 overflow-x-auto">
-    <eln-project-tab-button label="Notebook Info" [routerLink]="infoUrl" />
-    <eln-project-tab-button label="Experiments" [routerLink]="experimentsUrl" />
+    <eln-project-tab-button label="Notebook Info" [routerLink]="'/notebooks/' + notebookId" />
+    <eln-project-tab-button label="Experiments" [routerLink]="'/notebooks/' + notebookId + '/experiments'" />
   </div>
 </eln-card>
 

--- a/indigo-frontend/src/app/pages/notebook/notebook-detail/notebook-detail.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-detail/notebook-detail.component.ts
@@ -24,7 +24,6 @@ import { ProjectTabButtonComponent } from '@pages/project/project-tab-button/pro
     BreadcrumbsComponent,
     CommonModule,
   ],
-  providers: [NotebookService],
 })
 export class NotebookDetailComponent implements OnChanges {
   @Input() notebookId!: string;
@@ -32,23 +31,17 @@ export class NotebookDetailComponent implements OnChanges {
   dialog = inject(MatDialog);
   breadcrumbsState = inject(BreadcrumbsStateService);
 
-  get notebook() {
-    return this.store.notebook();
-  }
-
-  get isLoading() {
-    return this.store.isLoading();
-  }
-
-  get hasError() {
-    return this.store.hasError();
-  }
-
-  public infoUrl = '';
-  public experimentsUrl = '';
+  notebook = this.store.notebook;
+  isLoading = this.store.isLoading;
+  hasError = this.store.hasError;
 
   private readonly breadcrumbsEffect = effect(() => {
     const notebook = this.store.notebook();
+
+    if (!notebook) {
+      return;
+    }
+
     this.breadcrumbsState.setItems([
       { label: 'All Projects', url: '/projects', active: false },
       {
@@ -64,19 +57,15 @@ export class NotebookDetailComponent implements OnChanges {
   });
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['notebookId'] && this.notebookId) {
-      this.store.load(this.notebookId).subscribe((notebook) => {
-        this.infoUrl = `/notebooks/${notebook.id}`;
-        this.experimentsUrl = `/notebooks/${notebook.id}/experiments`;
-      });
+    if (changes['notebookId']) {
+      this.store.load(this.notebookId).subscribe();
     }
   }
 
   async openExperimentModal(): Promise<void> {
     const ref = this.dialog.open(ExperimentAddComponent);
-    const notebook = this.notebook;
 
-    ref.componentInstance.notebookId = notebook?.id;
+    ref.componentInstance.notebookId = this.notebookId;
 
     ref
       .afterClosed()

--- a/indigo-frontend/src/app/pages/notebook/notebook-detail/notebook-detail.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-detail/notebook-detail.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { Component, effect, inject, OnInit } from '@angular/core';
+import { Component, effect, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { ActivatedRoute, RouterOutlet } from '@angular/router';
+import { RouterOutlet } from '@angular/router';
 import { take } from 'rxjs';
 
 import { BreadcrumbsComponent } from '@/core/components/breadcrumbs/breadcrumbs.component';
@@ -26,8 +26,8 @@ import { ProjectTabButtonComponent } from '@pages/project/project-tab-button/pro
   ],
   providers: [NotebookService],
 })
-export class NotebookDetailComponent implements OnInit {
-  activatedRoute = inject(ActivatedRoute);
+export class NotebookDetailComponent implements OnChanges {
+  @Input() notebookId!: string;
   store = inject(NotebookService);
   dialog = inject(MatDialog);
   breadcrumbsState = inject(BreadcrumbsStateService);
@@ -63,17 +63,13 @@ export class NotebookDetailComponent implements OnInit {
     ]);
   });
 
-  ngOnInit(): void {
-    const notebookId = this.activatedRoute.snapshot.paramMap.get('notebookId');
-
-    if (!notebookId) {
-      return;
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['notebookId'] && this.notebookId) {
+      this.store.load(this.notebookId).subscribe((notebook) => {
+        this.infoUrl = `/notebooks/${notebook.id}`;
+        this.experimentsUrl = `/notebooks/${notebook.id}/experiments`;
+      });
     }
-
-    this.store.load(notebookId).subscribe((notebook) => {
-      this.infoUrl = `/notebooks/${notebook.id}`;
-      this.experimentsUrl = `/notebooks/${notebook.id}/experiments`;
-    });
   }
 
   async openExperimentModal(): Promise<void> {

--- a/indigo-frontend/src/app/pages/notebook/notebook-experiments-tab/notebook-experiments-tab.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-experiments-tab/notebook-experiments-tab.component.ts
@@ -6,11 +6,10 @@ import { ClassPickerPipe } from '@/core/pipes/classPicker.pipe';
 import { ExperimentDetail } from '@/core/types/entities/experiments/experiment-detail.i';
 import { animate, style, transition, trigger } from '@angular/animations';
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { ActivatedRoute } from '@angular/router';
 import { ExperimentItemComponent } from '@pages/experiment/experiment-item/experiment-item.component';
 import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
 
@@ -38,16 +37,19 @@ import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview
     ListHeaderComponent,
   ],
 })
-export class NotebookExperimentsTabComponent extends InfiniteScrollBase<ExperimentDetail> {
+export class NotebookExperimentsTabComponent extends InfiniteScrollBase<ExperimentDetail> implements OnInit, OnChanges {
   dialog = inject(MatDialog);
   selectedView: 'grid' | 'list' = 'grid';
-  notebookId = '';
+  @Input() notebookId!: string;
 
-  constructor(activatedRoute: ActivatedRoute) {
-    super();
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['notebookId'] && !changes['notebookId'].firstChange) {
+      this.config.loadUrl = `notebooks/${this.notebookId}/experiments`;
+      this.reload();
+    }
+  }
 
-    this.notebookId = activatedRoute.parent?.snapshot.paramMap.get('notebookId') ?? '';
-
+  ngOnInit(): void {
     this.setup({
       loadUrl: `notebooks/${this.notebookId}/experiments`,
       sortOptions: [

--- a/indigo-frontend/src/app/pages/notebook/notebook-experiments-tab/notebook-experiments-tab.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-experiments-tab/notebook-experiments-tab.component.ts
@@ -6,7 +6,7 @@ import { ClassPickerPipe } from '@/core/pipes/classPicker.pipe';
 import { ExperimentDetail } from '@/core/types/entities/experiments/experiment-detail.i';
 import { animate, style, transition, trigger } from '@angular/animations';
 import { CommonModule } from '@angular/common';
-import { Component, inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
@@ -37,27 +37,22 @@ import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview
     ListHeaderComponent,
   ],
 })
-export class NotebookExperimentsTabComponent extends InfiniteScrollBase<ExperimentDetail> implements OnInit, OnChanges {
+export class NotebookExperimentsTabComponent extends InfiniteScrollBase<ExperimentDetail> implements OnChanges {
   dialog = inject(MatDialog);
   selectedView: 'grid' | 'list' = 'grid';
   @Input() notebookId!: string;
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['notebookId'] && !changes['notebookId'].firstChange) {
-      this.config.loadUrl = `notebooks/${this.notebookId}/experiments`;
-      this.reload();
+    if (changes['notebookId']) {
+      this.setup({
+        loadUrl: `notebooks/${this.notebookId}/experiments`,
+        sortOptions: [
+          { label: 'Name', value: 'name' },
+          { label: 'Status', value: 'status' },
+          { label: 'Created Date', value: 'createdAt', defaultOrder: 'LATEST' },
+          { label: 'Modified Date', value: 'modifiedAt', defaultOrder: 'LATEST' },
+        ],
+      });
     }
-  }
-
-  ngOnInit(): void {
-    this.setup({
-      loadUrl: `notebooks/${this.notebookId}/experiments`,
-      sortOptions: [
-        { label: 'Name', value: 'name' },
-        { label: 'Status', value: 'status' },
-        { label: 'Created Date', value: 'createdAt', defaultOrder: 'LATEST' },
-        { label: 'Modified Date', value: 'modifiedAt', defaultOrder: 'LATEST' },
-      ],
-    });
   }
 }

--- a/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.html
@@ -1,14 +1,14 @@
-@if (isLoading) {
+@if (isLoading()) {
   <div class="flex items-center justify-center py-8">
     <span>Loading notebook...</span>
   </div>
-} @else if (hasError) {
+} @else if (hasError()) {
   <div class="flex items-center justify-center py-8">
     <div class="text-center">
       <span>There was an error loading the notebook, please try again later</span>
     </div>
   </div>
-} @else if (notebook) {
+} @else if (notebook()) {
   <div class="grid grid-cols-[1fr_auto] gap-4 pt-4">
     <eln-card>
       <div class="px-3">
@@ -23,22 +23,22 @@
         <div class="space-y-6 mt-3 text-sm">
           <div>
             <h3 class="font-semibold text-neutral-800 mb-2">Notebook Name</h3>
-            <p class="text-sm text-neutral-800">{{ notebook?.name ?? '' }}</p>
+            <p class="text-sm text-neutral-800">{{ notebook()?.name ?? '' }}</p>
           </div>
 
           <div>
             <h3 class="text-neutral-800 mb-2 font-semibold">Notebook Description</h3>
-            <div class="text-sm text-neutral-800 whitespace-pre-line" [innerHTML]="notebook?.description"></div>
+            <div class="text-sm text-neutral-800 whitespace-pre-line" [innerHTML]="notebook()?.description"></div>
           </div>
 
           <eln-attachments
-            [attachments]="notebook.attachments"
-            [baseURL]="`/api/eln/notebooks/${this.notebook.id}`"
+            [attachments]="notebook().attachments"
+            [baseURL]="`/api/eln/notebooks/${this.notebook().id}`"
             (attachmentsChanged)="onAttachmentsChanged($event)"
           />
         </div>
       </div>
     </eln-card>
-    <eln-team [team]="notebook.acl" [entityId]="notebook.id" [config]="notebookTeamConfig" />
+    <eln-team [team]="notebook().acl" [entityId]="notebook().id" [config]="notebookTeamConfig" />
   </div>
 }

--- a/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.ts
@@ -1,6 +1,5 @@
 import { ButtonComponent } from '@/core/components/common/button/button.component';
 import { CardComponent } from '@/core/components/common/card/card.component';
-import { NotebookDetail } from '@/core/types/entities/notebook-detail.i';
 import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { NotebookService } from '@core/services/notebook/notebook.service';
@@ -21,11 +20,15 @@ export class NotebookInfoComponent {
   private store = inject(NotebookService);
   private dialog = inject(MatDialog);
 
+  notebook = this.store.notebook;
+  isLoading = this.store.isLoading;
+  hasError = this.store.hasError;
+
   openEditDialog() {
-    if (!this.notebook) return;
+    if (!this.notebook()) return;
 
     const dialogRef = this.dialog.open(NotebookEditComponent, {
-      data: { notebook: this.notebook },
+      data: { notebook: this.notebook() },
       disableClose: true,
     });
 
@@ -38,19 +41,7 @@ export class NotebookInfoComponent {
     buildAccessEndpoint: (id: string) => `notebooks/${id}/access`,
   };
 
-  get notebook(): NotebookDetail | null {
-    return this.store.notebook();
-  }
-
-  get isLoading(): boolean {
-    return this.store.isLoading();
-  }
-
-  get hasError(): boolean {
-    return this.store.hasError();
-  }
-
   onAttachmentsChanged(attachments: Attachment[]) {
-    this.notebook.attachments = attachments;
+    this.notebook.update((n) => ({ ...n, attachments }));
   }
 }

--- a/indigo-frontend/src/app/pages/notebook/notebook-item/notebook-item.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-item/notebook-item.component.ts
@@ -18,14 +18,10 @@ import { Notebook } from '@/core/types/entities/notebook.i';
 export class NotebookItemComponent {
   private router = inject(Router);
 
-  @Input() notebook: Notebook;
+  @Input({ required: true }) notebook: Notebook;
   @Input() variant: 'grid' | 'list' = 'grid';
 
   openDetails(): void {
-    if (!this.notebook) {
-      return;
-    }
-
     this.router.navigateByUrl(`/notebooks/${this.notebook.id}`);
   }
 }

--- a/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.ts
@@ -1,6 +1,6 @@
 import { animate, style, transition, trigger } from '@angular/animations';
 import { CommonModule } from '@angular/common';
-import { Component, inject, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Component, inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
@@ -14,7 +14,7 @@ import { Notebook } from '@core/types/entities/notebook.i';
 import { NotebookAddComponent } from '@pages/notebook/notebook-add/notebook-add.component';
 import { NotebookItemComponent } from '@pages/notebook/notebook-item/notebook-item.component';
 import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
-import { Subscription, take } from 'rxjs';
+import { take } from 'rxjs';
 
 @Component({
   selector: 'eln-notebook-list',
@@ -40,41 +40,13 @@ import { Subscription, take } from 'rxjs';
     ListHeaderComponent,
   ],
 })
-export class NotebookListComponent extends InfiniteScrollBase<Notebook> implements OnInit, OnChanges, OnDestroy {
+export class NotebookListComponent extends InfiniteScrollBase<Notebook> implements OnInit, OnChanges {
   dialog = inject(MatDialog);
   selectedView: 'grid' | 'list' = 'grid';
-  private refreshSub!: Subscription;
   @Input() projectId!: string;
   headerSortOptions: DropdownMenuItem[] = [];
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['projectId'] && !changes['projectId'].firstChange) {
-      this.config.loadUrl = `projects/${this.projectId}/notebooks`;
-      this.reload();
-    }
-  }
-
-  ngOnInit(): void {
-    this.setup({
-      loadUrl: `projects/${this.projectId}/notebooks`,
-      sortOptions: [
-        {
-          label: 'Sorting by: Earliest',
-          value: 'createdAt',
-          defaultOrder: 'EARLIEST',
-        },
-        {
-          label: 'Sorting by: Latest',
-          value: 'createdAt',
-          defaultOrder: 'LATEST',
-        },
-      ],
-      defaultSort: {
-        sortBy: 'createdAt',
-        sort: 'EARLIEST',
-      },
-    });
-
+  ngOnInit() {
     this.headerSortOptions = this.getSortOptions().map((option) => ({
       label: `${option.label}`,
       value: `${option.value}:${option.defaultOrder}`,
@@ -82,12 +54,31 @@ export class NotebookListComponent extends InfiniteScrollBase<Notebook> implemen
     }));
   }
 
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['projectId']) {
+      this.setup({
+        loadUrl: `projects/${this.projectId}/notebooks`,
+        sortOptions: [
+          {
+            label: 'Sorting by: Earliest',
+            value: 'createdAt',
+            defaultOrder: 'EARLIEST',
+          },
+          {
+            label: 'Sorting by: Latest',
+            value: 'createdAt',
+            defaultOrder: 'LATEST',
+          },
+        ],
+        defaultSort: {
+          sortBy: 'createdAt',
+          sort: 'EARLIEST',
+        },
+      });
+    }
+  }
   refreshList(): void {
     this.reload();
-  }
-
-  ngOnDestroy(): void {
-    this.refreshSub?.unsubscribe();
   }
 
   async openModal() {

--- a/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.ts
@@ -1,10 +1,9 @@
 import { animate, style, transition, trigger } from '@angular/animations';
 import { CommonModule } from '@angular/common';
-import { Component, inject, OnDestroy } from '@angular/core';
+import { Component, inject, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { ActivatedRoute } from '@angular/router';
 import { ButtonComponent } from '@core/components/common/button/button.component';
 import { DropdownMenuItem } from '@core/components/common/dropdown-menu/dropdown-menu.i';
 import { ListHeaderComponent, SortChangeEvent } from '@core/components/common/list-header/list-header.component';
@@ -41,44 +40,46 @@ import { Subscription, take } from 'rxjs';
     ListHeaderComponent,
   ],
 })
-export class NotebookListComponent extends InfiniteScrollBase<Notebook> implements OnDestroy {
+export class NotebookListComponent extends InfiniteScrollBase<Notebook> implements OnInit, OnChanges, OnDestroy {
   dialog = inject(MatDialog);
   selectedView: 'grid' | 'list' = 'grid';
   private refreshSub!: Subscription;
-  projectId: string;
+  @Input() projectId!: string;
   headerSortOptions: DropdownMenuItem[] = [];
 
-  constructor(activatedRoute: ActivatedRoute) {
-    super();
-    activatedRoute.parent.params.pipe(take(1)).subscribe((params) => {
-      this.projectId = params['id'];
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['projectId'] && !changes['projectId'].firstChange) {
       this.config.loadUrl = `projects/${this.projectId}/notebooks`;
-      this.setup({
-        loadUrl: `projects/${this.projectId}/notebooks`,
-        sortOptions: [
-          {
-            label: 'Sorting by: Earliest',
-            value: 'createdAt',
-            defaultOrder: 'EARLIEST',
-          },
-          {
-            label: 'Sorting by: Latest',
-            value: 'createdAt',
-            defaultOrder: 'LATEST',
-          },
-        ],
-        defaultSort: {
-          sortBy: 'createdAt',
-          sort: 'EARLIEST',
-        },
-      });
+      this.reload();
+    }
+  }
 
-      this.headerSortOptions = this.getSortOptions().map((option) => ({
-        label: `${option.label}`,
-        value: `${option.value}:${option.defaultOrder}`,
-        icon: 'indicon-sort',
-      }));
+  ngOnInit(): void {
+    this.setup({
+      loadUrl: `projects/${this.projectId}/notebooks`,
+      sortOptions: [
+        {
+          label: 'Sorting by: Earliest',
+          value: 'createdAt',
+          defaultOrder: 'EARLIEST',
+        },
+        {
+          label: 'Sorting by: Latest',
+          value: 'createdAt',
+          defaultOrder: 'LATEST',
+        },
+      ],
+      defaultSort: {
+        sortBy: 'createdAt',
+        sort: 'EARLIEST',
+      },
     });
+
+    this.headerSortOptions = this.getSortOptions().map((option) => ({
+      label: `${option.label}`,
+      value: `${option.value}:${option.defaultOrder}`,
+      icon: 'indicon-sort',
+    }));
   }
 
   refreshList(): void {

--- a/indigo-frontend/src/app/pages/project/project-detail/project-detail.component.html
+++ b/indigo-frontend/src/app/pages/project/project-detail/project-detail.component.html
@@ -1,6 +1,6 @@
 <div *projectOverviewWidget="'tab'" class="flex items-center mt-6 overflow-x-auto">
-  <eln-project-tab-button label="Project Info" [routerLink]="projectUrl" />
-  <eln-project-tab-button label="Notebooks" [routerLink]="notebooksUrl" />
+  <eln-project-tab-button label="Project Info" [routerLink]="'/projects/' + this.projectId" />
+  <eln-project-tab-button label="Notebooks" [routerLink]="'/projects/' + this.projectId + '/notebooks'" />
 </div>
 
 <router-outlet />

--- a/indigo-frontend/src/app/pages/project/project-detail/project-detail.component.html
+++ b/indigo-frontend/src/app/pages/project/project-detail/project-detail.component.html
@@ -1,6 +1,6 @@
 <div *projectOverviewWidget="'tab'" class="flex items-center mt-6 overflow-x-auto">
-  <eln-project-tab-button label="Project Info" [routerLink]="'/projects/' + this.projectId" />
-  <eln-project-tab-button label="Notebooks" [routerLink]="'/projects/' + this.projectId + '/notebooks'" />
+  <eln-project-tab-button label="Project Info" [routerLink]="'/projects/' + projectId" />
+  <eln-project-tab-button label="Notebooks" [routerLink]="'/projects/' + projectId + '/notebooks'" />
 </div>
 
 <router-outlet />

--- a/indigo-frontend/src/app/pages/project/project-detail/project-detail.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-detail/project-detail.component.ts
@@ -1,7 +1,9 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, effect, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
 import { ProjectTabButtonComponent } from '@pages/project/project-tab-button/project-tab-button.component';
+import { ProjectService } from '@core/services/project/project.service';
+import { BreadcrumbsStateService } from '@core/services/breadcrumbs/breadcrumbs.state.service';
 
 @Component({
   selector: 'eln-project-detail',
@@ -11,13 +13,20 @@ import { ProjectTabButtonComponent } from '@pages/project/project-tab-button/pro
 export class ProjectDetailComponent implements OnChanges {
   @Input() projectId!: string;
 
-  public projectUrl = '';
-  public notebooksUrl = '';
+  projectService = inject(ProjectService);
+  breadcrumbsState = inject(BreadcrumbsStateService);
+
+  private readonly breadcrumbsEffect = effect(() => {
+    const project = this.projectService.project();
+    this.breadcrumbsState.setItems([
+      { label: 'All Projects', url: '/projects', active: false },
+      { label: `Project: ${project?.name ?? ''}`, active: true },
+    ]);
+  });
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['projectId']) {
-      this.projectUrl = `/projects/${this.projectId}`;
-      this.notebooksUrl = `${this.projectUrl}/notebooks`;
+      this.projectService.load(this.projectId).subscribe();
     }
   }
 }

--- a/indigo-frontend/src/app/pages/project/project-detail/project-detail.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-detail/project-detail.component.ts
@@ -1,5 +1,5 @@
-import { Component, inject, OnInit } from '@angular/core';
-import { ActivatedRoute, RouterOutlet } from '@angular/router';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
 import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
 import { ProjectTabButtonComponent } from '@pages/project/project-tab-button/project-tab-button.component';
 
@@ -8,16 +8,16 @@ import { ProjectTabButtonComponent } from '@pages/project/project-tab-button/pro
   templateUrl: './project-detail.component.html',
   imports: [RouterOutlet, ProjectOverviewWidgetDirective, ProjectTabButtonComponent],
 })
-export class ProjectDetailComponent implements OnInit {
-  activedRoute = inject(ActivatedRoute);
+export class ProjectDetailComponent implements OnChanges {
+  @Input() projectId!: string;
 
   public projectUrl = '';
   public notebooksUrl = '';
 
-  ngOnInit() {
-    this.activedRoute.params.subscribe((params) => {
-      this.projectUrl = `/projects/${params['id']}`;
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['projectId']) {
+      this.projectUrl = `/projects/${this.projectId}`;
       this.notebooksUrl = `${this.projectUrl}/notebooks`;
-    });
+    }
   }
 }

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
@@ -8,7 +8,7 @@
       <span>There was an error loading the project, please try again later</span>
     </div>
   </div>
-} @else if (project) {
+} @else if (project()) {
   <div class="grid grid-cols-[1fr_auto] gap-4 pt-4">
     <eln-card>
       <div class="flex items-center justify-between pb-3 border-b border-b-neutral-200">

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
@@ -1,8 +1,8 @@
-@if (isLoading) {
+@if (isLoading()) {
   <div class="flex items-center justify-center py-8">
     <span>Loading project...</span>
   </div>
-} @else if (hasError) {
+} @else if (hasError()) {
   <div class="flex items-center justify-center py-8">
     <div class="text-center">
       <span>There was an error loading the project, please try again later</span>
@@ -22,13 +22,13 @@
       <div class="space-y-6 mt-3 text-sm">
         <div>
           <h3 class="font-semibold text-neutral-800 mb-2">Project Name</h3>
-          <p class="text-neutral-1000">{{ project.name }}</p>
+          <p class="text-neutral-1000">{{ project().name }}</p>
         </div>
 
         <div>
           <h3 class="text-neutral-800 mb-2 font-semibold">Project Keywords</h3>
           <div class="flex flex-wrap gap-2">
-            @for (keyword of project.keywords; track keyword) {
+            @for (keyword of project().keywords; track keyword) {
               <eln-chip>{{ keyword }}</eln-chip>
             }
           </div>
@@ -36,24 +36,24 @@
 
         <div>
           <h3 class="text-neutral-800 mb-2 font-semibold">Literature</h3>
-          <p class="text-neutral-1000">{{ project.literature || '-' }}</p>
+          <p class="text-neutral-1000">{{ project().literature || '-' }}</p>
         </div>
 
         <div>
           <h3 class="text-neutral-800 mb-2 font-semibold">Project Details</h3>
-          <p class="text-neutral-1000" [innerHTML]="project.description"></p>
-          <p class="text-neutral-1000 mt-4">{{ project.details }}</p>
+          <p class="text-neutral-1000" [innerHTML]="project().description"></p>
+          <p class="text-neutral-1000 mt-4">{{ project().details }}</p>
         </div>
 
         <eln-attachments
-          [attachments]="project.attachments"
-          [baseURL]="'/api/eln/projects/' + project.id"
+          [attachments]="project().attachments"
+          [baseURL]="'/api/eln/projects/' + project().id"
           (attachmentsChanged)="onAttachmentsChanged($event)"
         />
       </div>
     </eln-card>
 
-    <eln-team [team]="project.acl" [entityId]="project.id" [config]="projectTeamConfig" />
+    <eln-team [team]="project().acl" [entityId]="project().id" [config]="projectTeamConfig" />
   </div>
 }
 

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -4,17 +4,16 @@ import { CardComponent } from '@/core/components/common/card/card.component';
 import { ChipComponent } from '@/core/components/common/chip/chip.component';
 import { TeamComponent } from '@/core/components/common/team/team.component';
 import { TeamComponentConfig } from '@/core/components/common/team/team.config';
-import { ApiService } from '@/core/services/api.service';
-import { BreadcrumbsStateService } from '@/core/services/breadcrumbs/breadcrumbs.state.service';
 import { Attachment } from '@/core/types/entities/attachment.i';
-import { Project } from '@/core/types/entities/project.i';
 import { CommonModule } from '@angular/common';
-import { Component, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, inject, Input } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { NotebookAddComponent } from '@pages/notebook/notebook-add/notebook-add.component';
 import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
-import { finalize, take } from 'rxjs';
+import { take } from 'rxjs';
 import { ProjectAddComponent } from '../project-add/project-add.component';
+import { ProjectService } from '@core/services/project/project.service';
+import { Router } from '@angular/router';
 
 enum projectInfoModalEnum {
   EDIT = 'edit',
@@ -35,61 +34,28 @@ enum projectInfoModalEnum {
   ],
   templateUrl: './project-info.component.html',
 })
-export class ProjectInfoComponent implements OnChanges {
+export class ProjectInfoComponent {
   projectInfoModalEnum = projectInfoModalEnum;
 
   @Input() projectId!: string;
   dialog = inject(MatDialog);
-  service = inject(ApiService);
-  breadcrumbsState = inject(BreadcrumbsStateService);
+  projectService = inject(ProjectService);
+  router = inject(Router);
 
-  project: Project | null = null;
-
-  isLoading = false;
-  hasError = false;
+  project = this.projectService.project;
+  isLoading = this.projectService.isLoading;
+  hasError = this.projectService.hasError;
 
   projectTeamConfig: TeamComponentConfig = {
     buildAccessEndpoint: (id: string) => `projects/${id}/access`,
   };
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['projectId']) {
-      this.breadcrumbsState.setItems([
-        { label: 'All Projects', url: '/projects', active: false },
-        { label: 'Project: ', active: true },
-      ]);
-      this.loadProject(this.projectId);
-    }
-  }
-
   onAttachmentsChanged(attachments: Attachment[]) {
-    if (!this.project) {
+    if (!this.project()) {
       return;
     }
 
-    this.project.attachments = attachments;
-  }
-
-  private loadProject(id: string): void {
-    this.isLoading = true;
-    this.hasError = false;
-
-    this.service
-      .request<Project>('get', `projects/${id}`)
-      .pipe(finalize(() => (this.isLoading = false)))
-      .subscribe({
-        next: (project) => {
-          this.project = project;
-
-          this.breadcrumbsState.setItems([
-            { label: 'All Projects', url: '/projects', active: false },
-            { label: `Project: ${project.name}`, active: true },
-          ]);
-        },
-        error: () => {
-          this.hasError = true;
-        },
-      });
+    this.project.update((p) => ({ ...p, attachments }));
   }
 
   async openModal(mode: projectInfoModalEnum) {
@@ -98,22 +64,22 @@ export class ProjectInfoComponent implements OnChanges {
     if (mode === projectInfoModalEnum.EDIT) {
       ref = this.dialog.open(ProjectAddComponent, {
         data: {
-          project: this.project,
+          project: this.project(),
         },
       });
     }
 
-    if (mode === projectInfoModalEnum.NOTEBOOK && this.project) {
+    if (mode === projectInfoModalEnum.NOTEBOOK) {
       ref = this.dialog.open(NotebookAddComponent);
-      (ref.componentInstance as NotebookAddComponent).projectId = this.project.id;
+      (ref.componentInstance as NotebookAddComponent).projectId = this.projectId;
     }
 
     ref
       ?.afterClosed()
       .pipe(take(1))
       .subscribe((result) => {
-        if (result === 'refresh' && this.project) {
-          this.loadProject(this.project.id);
+        if (result === 'refresh' && mode === projectInfoModalEnum.EDIT) {
+          this.projectService.refresh();
         }
       });
   }

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -9,13 +9,11 @@ import { BreadcrumbsStateService } from '@/core/services/breadcrumbs/breadcrumbs
 import { Attachment } from '@/core/types/entities/attachment.i';
 import { Project } from '@/core/types/entities/project.i';
 import { CommonModule } from '@angular/common';
-import { Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { ActivatedRoute } from '@angular/router';
 import { NotebookAddComponent } from '@pages/notebook/notebook-add/notebook-add.component';
 import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
-import { finalize, Subject, take } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { finalize, take } from 'rxjs';
 import { ProjectAddComponent } from '../project-add/project-add.component';
 
 enum projectInfoModalEnum {
@@ -37,10 +35,10 @@ enum projectInfoModalEnum {
   ],
   templateUrl: './project-info.component.html',
 })
-export class ProjectInfoComponent implements OnInit, OnDestroy {
+export class ProjectInfoComponent implements OnChanges {
   projectInfoModalEnum = projectInfoModalEnum;
 
-  activatedRoute = inject(ActivatedRoute);
+  @Input() projectId!: string;
   dialog = inject(MatDialog);
   service = inject(ApiService);
   breadcrumbsState = inject(BreadcrumbsStateService);
@@ -50,28 +48,18 @@ export class ProjectInfoComponent implements OnInit, OnDestroy {
   isLoading = false;
   hasError = false;
 
-  private destroy$ = new Subject<void>();
-
   projectTeamConfig: TeamComponentConfig = {
     buildAccessEndpoint: (id: string) => `projects/${id}/access`,
   };
 
-  ngOnInit() {
-    this.breadcrumbsState.setItems([
-      { label: 'All Projects', url: '/projects', active: false },
-      { label: 'Project: ', active: true },
-    ]);
-
-    this.activatedRoute.params.pipe(takeUntil(this.destroy$)).subscribe(({ id }) => {
-      if (id) {
-        this.loadProject(id);
-      }
-    });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['projectId']) {
+      this.breadcrumbsState.setItems([
+        { label: 'All Projects', url: '/projects', active: false },
+        { label: 'Project: ', active: true },
+      ]);
+      this.loadProject(this.projectId);
+    }
   }
 
   onAttachmentsChanged(attachments: Attachment[]) {

--- a/indigo-frontend/src/app/pages/project/project-layout/project-layout.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-layout/project-layout.component.ts
@@ -1,6 +1,6 @@
 import { RouteAnimationType } from '@/core/animations/route-animations';
 import { AnimatedRouteContainerComponent } from '@/core/components/common/animated-route-container/animated-route-container.component';
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { ProjectsOverviewWidgetComponent } from '@pages/project/projects-overview-widget/projects-overview-widget.component';
 
@@ -12,4 +12,6 @@ import { ProjectsOverviewWidgetComponent } from '@pages/project/projects-overvie
 })
 export class ProjectLayoutComponent {
   animationType = RouteAnimationType.SlideRight;
+
+  @Input() projectId!: string;
 }

--- a/indigo-frontend/src/app/pages/project/project-list/project-list.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-list/project-list.component.ts
@@ -56,13 +56,7 @@ export class ProjectListComponent extends InfiniteScrollBase<Project> implements
 
     // breadcrumbs are shown in ProjectsOverviewWidgetComponent, but initialized here, because
     // ProjectsOverviewWidgetComponent is not reinitialized when navigating inside /projects paths
-    this.breadcrumbsState.setItems([
-      {
-        label: 'All Projects',
-        url: '/projects',
-        active: true,
-      },
-    ]);
+    this.breadcrumbsState.setItems([{ label: 'All Projects', url: '/projects', active: true }]);
 
     this.setup({
       loadUrl: 'projects',

--- a/indigo-frontend/src/core/components/common/image/api-image.component.ts
+++ b/indigo-frontend/src/core/components/common/image/api-image.component.ts
@@ -10,8 +10,8 @@ import { ApiService } from '@core/services/api.service';
   imports: [CommonModule, IsInViewportDirective],
 })
 export class ApiImageComponent implements OnChanges {
-  @Input() url: string;
-  @Input() blob: string;
+  @Input() url: string | undefined;
+  @Input() blob: string | undefined;
   @Input() altText = '';
   api = inject(ApiService);
 

--- a/indigo-frontend/src/core/components/common/team/team.component.ts
+++ b/indigo-frontend/src/core/components/common/team/team.component.ts
@@ -57,7 +57,7 @@ interface TeamLoadingState {
   ],
 })
 export class TeamComponent implements OnInit {
-  @Input() entityId?: string;
+  @Input({ required: true }) entityId: string;
   @Input() set team(value: ACLEntry[]) {
     this._team.set(value);
     this.rebuildSuggestionsState();
@@ -92,7 +92,6 @@ export class TeamComponent implements OnInit {
   @ViewChild(NgSelectComponent) ngSelectComponent!: NgSelectComponent;
 
   ngOnInit(): void {
-    if (!this.entityId) console.warn('TeamComponent initialized without entityId');
     this.loading.update((l) => ({ ...l, suggestions: true }));
     this.api
       .request<UserRef[]>('get', 'users/suggest')
@@ -171,7 +170,6 @@ export class TeamComponent implements OnInit {
 
   private endpoint(): string {
     const id = this.entityId;
-    if (!id) return '';
     return this.config.buildAccessEndpoint(id);
   }
 

--- a/indigo-frontend/src/core/components/util/infinite-scroll.base.ts
+++ b/indigo-frontend/src/core/components/util/infinite-scroll.base.ts
@@ -1,4 +1,6 @@
 import { ensureDistinct } from '@/core/utils/array.util';
+import { DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { PaginatedBase } from './paginated.base';
 
@@ -9,17 +11,18 @@ export abstract class InfiniteScrollBase<T> extends PaginatedBase<T> {
   protected override isLoading = false;
 
   private isInfiniteLoaderVisible = false;
+  private destroyRef = inject(DestroyRef);
   private dataListSub?: Subscription;
 
-  protected override initialize(): void {
+  protected override reinitialize(): void {
     this.dataListSub?.unsubscribe();
     this.dataBh.next([]);
     this.pager.pageNo = 0;
 
-    super.initialize();
+    super.reinitialize();
     this.config.enableScrollRestoration = true;
 
-    this.dataListSub = this.dataList$.subscribe((data) => {
+    this.dataListSub = this.dataList$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data) => {
       const currValue = this.dataBh.value;
       const result = this.appendToTop ? [...data.items, ...currValue] : [...currValue, ...data.items];
 

--- a/indigo-frontend/src/core/components/util/infinite-scroll.base.ts
+++ b/indigo-frontend/src/core/components/util/infinite-scroll.base.ts
@@ -1,5 +1,5 @@
 import { ensureDistinct } from '@/core/utils/array.util';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { PaginatedBase } from './paginated.base';
 
 export abstract class InfiniteScrollBase<T> extends PaginatedBase<T> {
@@ -9,13 +9,17 @@ export abstract class InfiniteScrollBase<T> extends PaginatedBase<T> {
   protected override isLoading = false;
 
   private isInfiniteLoaderVisible = false;
+  private dataListSub?: Subscription;
 
   protected override initialize(): void {
+    this.dataListSub?.unsubscribe();
+    this.dataBh.next([]);
+    this.pager.pageNo = 0;
+
     super.initialize();
     this.config.enableScrollRestoration = true;
 
-    // 2. Clearer data management: avoid side effects inside switchMap
-    this.dataList$.subscribe((data) => {
+    this.dataListSub = this.dataList$.subscribe((data) => {
       const currValue = this.dataBh.value;
       const result = this.appendToTop ? [...data.items, ...currValue] : [...currValue, ...data.items];
 

--- a/indigo-frontend/src/core/components/util/paginated.base.ts
+++ b/indigo-frontend/src/core/components/util/paginated.base.ts
@@ -52,10 +52,10 @@ export abstract class PaginatedBase<T> {
       this.pager.sort = config.defaultSort.sort;
     }
 
-    this.initialize();
+    this.reinitialize();
   }
 
-  protected initialize() {
+  protected reinitialize() {
     // Initiate rxjs logic
     const dataLogic$ = this.dataSubject$.pipe(
       switchMap((res) => {

--- a/indigo-frontend/src/core/services/project/project.service.ts
+++ b/indigo-frontend/src/core/services/project/project.service.ts
@@ -1,29 +1,29 @@
 import { Injectable, signal } from '@angular/core';
-import { NotebookDetail } from '@/core/types/entities/notebook-detail.i';
 import { ApiService } from '@/core/services/api.service';
 import { catchError, finalize, tap, throwError } from 'rxjs';
+import { Project } from '@core/types/entities/project.i';
 
 @Injectable({
   providedIn: 'root',
 })
-export class NotebookService {
+export class ProjectService {
   constructor(private api: ApiService<unknown>) {}
 
-  // Signals to hold the current notebook state
-  readonly notebook = signal<NotebookDetail | null>(null);
+  // Signals to hold the current project state
+  readonly project = signal<Project | null>(null);
   readonly isLoading = signal<boolean>(false);
   readonly hasError = signal<boolean>(false);
   private readonly currentId = signal<string | null>(null);
 
   load(id: string) {
     this.currentId.set(id);
-    this.notebook.set(null);
+    this.project.set(null);
     this.isLoading.set(true);
     this.hasError.set(false);
 
-    return this.api.request<NotebookDetail>('get', `notebooks/${id}`).pipe(
-      tap((notebook) => {
-        this.notebook.set(notebook);
+    return this.api.request<Project>('get', `projects/${id}`).pipe(
+      tap((project) => {
+        this.project.set(project);
       }),
       catchError((error) => {
         this.hasError.set(true);
@@ -37,12 +37,12 @@ export class NotebookService {
 
   refresh() {
     const id = this.currentId();
-    if (id) this.load(id).subscribe();
+    if (id) this.load(id);
   }
 
   reset() {
     this.currentId.set(null);
-    this.notebook.set(null);
+    this.project.set(null);
     this.isLoading.set(false);
     this.hasError.set(false);
   }

--- a/indigo-frontend/src/core/services/project/project.service.ts
+++ b/indigo-frontend/src/core/services/project/project.service.ts
@@ -37,7 +37,7 @@ export class ProjectService {
 
   refresh() {
     const id = this.currentId();
-    if (id) this.load(id);
+    if (id) this.load(id).subscribe();
   }
 
   reset() {


### PR DESCRIPTION
- Migrate route parameter extraction from ActivatedRoute to Angular's withComponentInputBinding() + paramsInheritanceStrategy: 'always', so route parameters (including parents) are always available as @Input parameters

- Add ProjectService in the same way as NotebookService; made them singletons to enable reuse data between different components

- In project/notebook details components, trigger load in ProjectService/NotebookService; implement ngOnChanges to catch changes in route parameters

- Fix subscription leak in InfiniteScrollBase.initialize() — store the dataList$ subscription and unsubscribe before re-initializing, resetting list and page state on context switch

- Unified breadcrumbs initialization in project and notebook routes