### PR TITLE
feat(737): change title by route

### DIFF
--- a/indigo-frontend/src/app/app.component.local.ts
+++ b/indigo-frontend/src/app/app.component.local.ts
@@ -1,5 +1,7 @@
+import { ActivatedRoute, NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+import { filter } from 'rxjs';
 
 @Component({
   selector: 'eln-root',
@@ -10,15 +12,32 @@ import { RouterOutlet } from '@angular/router';
 export class AppComponent implements OnInit {
   title = 'indigo-frontend';
 
+  constructor(
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private titleService: Title,
+  ) {}
+
   /**
    * Initialize Keycloak authentication when the component is loaded.
    */
   async ngOnInit(): Promise<void> {
-    //const authenticated = await provideKeycloak.init();
-    //if (authenticated) {
-    //    console.log('User is authenticated');
-    //} else {
-    //    console.log('User is not authenticated');
-    //}
+    this.setPageTitleOnNavigation();
+  }
+
+  private setPageTitleOnNavigation(): void {
+    this.router.events.pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd)).subscribe(() => {
+      const title = this.getDeepestRouteTitle(this.activatedRoute) ?? 'IndigoELN';
+      this.titleService.setTitle(title);
+    });
+  }
+
+  private getDeepestRouteTitle(route: ActivatedRoute): string | null {
+    let title = route.snapshot.data?.['title'] ?? null;
+    while (route.firstChild) {
+      route = route.firstChild;
+      title = route.snapshot.data?.['title'] ?? title;
+    }
+    return title;
   }
 }

--- a/indigo-frontend/src/app/app.component.ts
+++ b/indigo-frontend/src/app/app.component.ts
@@ -1,8 +1,10 @@
-import { RouterOutlet } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
 import { defaultStorage, sessionStorage } from 'aws-amplify/utils';
 import { cognitoUserPoolsTokenProvider } from 'aws-amplify/auth/cognito';
 import { Component, OnInit } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { filter } from 'rxjs';
 
 @Component({
   selector: 'eln-root',
@@ -14,6 +16,13 @@ import { Component, OnInit } from '@angular/core';
 export class AppComponent implements OnInit {
   title = 'indigo-frontend';
   isRemembered = false;
+
+  constructor(
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private titleService: Title,
+  ) {}
+
   ngOnInit() {
     const hasLocalStorage = Object.keys(localStorage).some((key) => key.startsWith('CognitoIdentityServiceProvider'));
 
@@ -24,7 +33,26 @@ export class AppComponent implements OnInit {
       this.isRemembered = false;
       cognitoUserPoolsTokenProvider.setKeyValueStorage(sessionStorage);
     }
+
+    this.setPageTitleOnNavigation();
   }
+
+  private setPageTitleOnNavigation(): void {
+    this.router.events.pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd)).subscribe(() => {
+      const title = this.getDeepestRouteTitle(this.activatedRoute) ?? 'IndigoELN';
+      this.titleService.setTitle(title);
+    });
+  }
+
+  private getDeepestRouteTitle(route: ActivatedRoute): string | null {
+    let title = route.snapshot.data?.['title'] ?? null;
+    while (route.firstChild) {
+      route = route.firstChild;
+      title = route.snapshot.data?.['title'] ?? title;
+    }
+    return title;
+  }
+
   onRememberMeChange(event: any) {
     const isChecked = (event.target as HTMLInputElement).checked;
     this.isRemembered = isChecked;

--- a/indigo-frontend/src/app/app.routes.ts
+++ b/indigo-frontend/src/app/app.routes.ts
@@ -34,7 +34,7 @@ export const routes: Routes = [
                 path: '',
                 loadComponent: () =>
                   import('@pages/project/project-info/project-info.component').then((c) => c.ProjectInfoComponent),
-                data: { title: 'IndigoELN - Project Overview' },
+                data: { title: 'IndigoELN - Project' },
               },
               {
                 path: 'notebooks',
@@ -58,7 +58,7 @@ export const routes: Routes = [
             path: '',
             loadComponent: () =>
               import('@/app/pages/notebook/notebook-info/notebook-info.component').then((c) => c.NotebookInfoComponent),
-            data: { title: 'IndigoELN - Notebook Info' },
+            data: { title: 'IndigoELN - Notebook' },
           },
           {
             path: 'experiments',
@@ -77,7 +77,7 @@ export const routes: Routes = [
             (c) => c.DictionaryLayoutComponent,
           ),
         canActivate: [RoleGuard],
-        data: { requiredPermission: 'MANAGE_DICTIONARIES', title: 'IndigoELN - Dictionary' },
+        data: { requiredPermission: 'MANAGE_DICTIONARIES' },
       },
       {
         path: 'experiments/:experimentId',
@@ -85,13 +85,11 @@ export const routes: Routes = [
           import('@/app/pages/experiment/experiment-layout/experiment-layout.component').then(
             (c) => c.ExperimentLayoutComponent,
           ),
-        data: { title: 'IndigoELN - Experiment' },
       },
       {
         path: 'templates',
         loadComponent: () =>
           import('@pages/template/template-layout/template-layout.component').then((c) => c.TemplateLayoutComponent),
-        data: { title: 'IndigoELN - Templates' },
       },
       {
         path: 'signatures',
@@ -100,13 +98,12 @@ export const routes: Routes = [
             (c) => c.SignatureLayoutComponent,
           ),
         canActivate: [RoleGuard],
-        data: { requiredPermission: 'SIGN_EXPERIMENTS', title: 'IndigoELN - Signatures' },
+        data: { requiredPermission: 'SIGN_EXPERIMENTS' },
         children: [
           {
             path: '',
             loadComponent: () =>
               import('@pages/signature/signature-list/signature-list.component').then((c) => c.SignatureListComponent),
-            data: { title: 'IndigoELN - Signatures' },
           },
         ],
       },

--- a/indigo-frontend/src/app/app.routes.ts
+++ b/indigo-frontend/src/app/app.routes.ts
@@ -16,26 +16,31 @@ export const routes: Routes = [
         path: 'projects',
         loadComponent: () =>
           import('@pages/project/project-layout/project-layout.component').then((c) => c.ProjectLayoutComponent),
+        data: { title: 'IndigoELN - Projects' },
         children: [
           {
             path: '',
             loadComponent: () =>
               import('@pages/project/project-list/project-list.component').then((c) => c.ProjectListComponent),
+            data: { title: 'IndigoELN - Projects' },
           },
           {
             path: ':projectId',
             loadComponent: () =>
               import('@pages/project/project-detail/project-detail.component').then((c) => c.ProjectDetailComponent),
+            data: { title: 'IndigoELN - Project' },
             children: [
               {
                 path: '',
                 loadComponent: () =>
                   import('@pages/project/project-info/project-info.component').then((c) => c.ProjectInfoComponent),
+                data: { title: 'IndigoELN - Project Overview' },
               },
               {
                 path: 'notebooks',
                 loadComponent: () =>
                   import('@pages/notebook/notebook-list/notebook-list.component').then((c) => c.NotebookListComponent),
+                data: { title: 'IndigoELN - Project Notebooks' },
               },
             ],
           },
@@ -47,11 +52,13 @@ export const routes: Routes = [
           import('@/app/pages/notebook/notebook-detail/notebook-detail.component').then(
             (c) => c.NotebookDetailComponent,
           ),
+        data: { title: 'IndigoELN - Notebook' },
         children: [
           {
             path: '',
             loadComponent: () =>
               import('@/app/pages/notebook/notebook-info/notebook-info.component').then((c) => c.NotebookInfoComponent),
+            data: { title: 'IndigoELN - Notebook Info' },
           },
           {
             path: 'experiments',
@@ -59,6 +66,7 @@ export const routes: Routes = [
               import('@pages/notebook/notebook-experiments-tab/notebook-experiments-tab.component').then(
                 (c) => c.NotebookExperimentsTabComponent,
               ),
+            data: { title: 'IndigoELN - Notebook Experiments' },
           },
         ],
       },
@@ -69,7 +77,7 @@ export const routes: Routes = [
             (c) => c.DictionaryLayoutComponent,
           ),
         canActivate: [RoleGuard],
-        data: { requiredPermission: 'MANAGE_DICTIONARIES' },
+        data: { requiredPermission: 'MANAGE_DICTIONARIES', title: 'IndigoELN - Dictionary' },
       },
       {
         path: 'experiments/:experimentId',
@@ -77,11 +85,13 @@ export const routes: Routes = [
           import('@/app/pages/experiment/experiment-layout/experiment-layout.component').then(
             (c) => c.ExperimentLayoutComponent,
           ),
+        data: { title: 'IndigoELN - Experiment' },
       },
       {
         path: 'templates',
         loadComponent: () =>
           import('@pages/template/template-layout/template-layout.component').then((c) => c.TemplateLayoutComponent),
+        data: { title: 'IndigoELN - Templates' },
       },
       {
         path: 'signatures',
@@ -90,12 +100,13 @@ export const routes: Routes = [
             (c) => c.SignatureLayoutComponent,
           ),
         canActivate: [RoleGuard],
-        data: { requiredPermission: 'SIGN_EXPERIMENTS' },
+        data: { requiredPermission: 'SIGN_EXPERIMENTS', title: 'IndigoELN - Signatures' },
         children: [
           {
             path: '',
             loadComponent: () =>
               import('@pages/signature/signature-list/signature-list.component').then((c) => c.SignatureListComponent),
+            data: { title: 'IndigoELN - Signatures' },
           },
         ],
       },

--- a/indigo-frontend/src/app/pages/experiment/experiment-layout/experiment-layout.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/experiment-layout/experiment-layout.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, effect, inject, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 import { BreadcrumbsComponent } from '@/core/components/breadcrumbs/breadcrumbs.component';
@@ -50,6 +51,7 @@ export class ExperimentLayoutComponent implements OnChanges, OnDestroy {
   @Input() experimentId!: string;
   experimentDetailService = inject(ExperimentDetailService);
   breadcrumbsState = inject(BreadcrumbsStateService);
+  titleService = inject(Title);
 
   experiment = computed<ExperimentDetail | null>(() => this.experimentDetailService.experimentDetail());
   template = computed(() => this.experimentDetailService.experimentTemplate());
@@ -83,6 +85,15 @@ export class ExperimentLayoutComponent implements OnChanges, OnDestroy {
         active: true,
       },
     ]);
+  });
+
+  private readonly titleEffect = effect(() => {
+    const experiment = this.experiment();
+    if (!experiment) {
+      return;
+    }
+
+    this.titleService.setTitle(`IndigoELN - ${experiment.name ?? 'Experiment'}`);
   });
 
   private readonly tabsEffect = effect(() => {

--- a/indigo-frontend/src/app/pages/notebook/notebook-detail/notebook-detail.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-detail/notebook-detail.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, effect, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { RouterOutlet } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 import { take } from 'rxjs';
 
 import { BreadcrumbsComponent } from '@/core/components/breadcrumbs/breadcrumbs.component';
@@ -30,6 +31,7 @@ export class NotebookDetailComponent implements OnChanges {
   store = inject(NotebookService);
   dialog = inject(MatDialog);
   breadcrumbsState = inject(BreadcrumbsStateService);
+  titleService = inject(Title);
 
   notebook = this.store.notebook;
   isLoading = this.store.isLoading;
@@ -54,6 +56,14 @@ export class NotebookDetailComponent implements OnChanges {
         active: true,
       },
     ]);
+  });
+
+  private readonly titleEffect = effect(() => {
+    const notebook = this.store.notebook();
+    if (!notebook) {
+      return;
+    }
+    this.titleService.setTitle(`IndigoELN - ${notebook.name ?? 'Notebook'}`);
   });
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/indigo-frontend/src/app/pages/project/project-detail/project-detail.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-detail/project-detail.component.ts
@@ -1,5 +1,6 @@
 import { Component, effect, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
 import { ProjectTabButtonComponent } from '@pages/project/project-tab-button/project-tab-button.component';
 import { ProjectService } from '@core/services/project/project.service';
@@ -15,6 +16,7 @@ export class ProjectDetailComponent implements OnChanges {
 
   projectService = inject(ProjectService);
   breadcrumbsState = inject(BreadcrumbsStateService);
+  titleService = inject(Title);
 
   private readonly breadcrumbsEffect = effect(() => {
     const project = this.projectService.project();
@@ -22,6 +24,14 @@ export class ProjectDetailComponent implements OnChanges {
       { label: 'All Projects', url: '/projects', active: false },
       { label: `Project: ${project?.name ?? ''}`, active: true },
     ]);
+  });
+
+  private readonly titleEffect = effect(() => {
+    const project = this.projectService.project();
+    if (!project) {
+      return;
+    }
+    this.titleService.setTitle(`IndigoELN - ${project.name ?? 'Project'}`);
   });
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
## Related Task

* Resolves [#737](https://github.com/epam/Indigo-ELN-v.-2.0/issues/737)

## Description

This PR adds support for dynamically updating the browser tab title based on the active route in `indigo-frontend`.

## Changes Made

* **`app.component.ts`**:
  * Added logic to listen for `NavigationEnd` events.
  * Used Angular's `Title` service to automatically update `document.title`.
  * Determines and assigns the title from the deepest active route in nested route scenarios.

* **`app.component.local.ts`**:
  * Applied the same dynamic title logic for the local environment setup.

* **`app.routes.ts`**:
  * Added `data.title` properties to key routes:
    * `projects`
    * `projects/:projectId`
    * `notebooks/:notebookId`
    * `experiments/:experimentId`
    * `templates`
    * `dictionary`
    * `signatures`

## Benefits

* The browser title is no longer static and accurately reflects the current page.
* Improves usability when working across multiple open tabs.
* Allows quick identification of the section currently being viewed.

## Evidence

https://github.com/user-attachments/assets/01cfc500-f3a0-4c2d-9303-454c279bf89b

[

https://github.com/user-attachments/assets/da65cab0-1b33-400b-aaff-04e35224e38c

](url)



