### PR TITLE
feat(722): [FE] Access Control for Notebooks API

### DIFF
--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.html
@@ -8,6 +8,6 @@
   [contentError]="loadError"
   [submitFn]="createNotebookFn"
   [toastMessages]="{ uniqueName: uniqueNameToastMessage }"
-  [submitEnabled]="canCreateNotebook()"
+  [submitEnabled]="projectService.canCreateNotebook()"
   submitButtonText="Save"
 ></eln-form-dialog>

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.html
@@ -8,5 +8,6 @@
   [contentError]="loadError"
   [submitFn]="createNotebookFn"
   [toastMessages]="{ uniqueName: uniqueNameToastMessage }"
+  [submitEnabled]="canCreateNotebook()"
   submitButtonText="Save"
 ></eln-form-dialog>

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
@@ -2,7 +2,7 @@ import { FormDialogComponent } from '@core/components/common/form-dialog/form-di
 import { ApiService } from '@core/services/api.service';
 import { Notebook } from '@core/types/entities/notebook.i';
 import { CommonModule } from '@angular/common';
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, computed, inject, OnInit } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
@@ -13,6 +13,8 @@ import { catchError, map, of, switchMap, tap } from 'rxjs';
 import { NotificationType } from '@/core/types/notification.i';
 import { NotificationService } from '@/core/services/notification/notification.service';
 import { Router } from '@angular/router';
+import { PermissionService } from '@core/services/permission/permission.service';
+import { ApplicationPermission } from '@core/types/entities/user.i';
 
 @Component({
   standalone: true,
@@ -28,6 +30,10 @@ export class NotebookAddComponent implements OnInit {
   dialogRef = inject(MatDialogRef);
   notificationService = inject(NotificationService);
   router = inject(Router);
+  permissionService = inject(PermissionService);
+  canCreateNotebook = computed(() =>
+    this.permissionService.hasGlobalPermission(ApplicationPermission.CREATE_NOTEBOOKS),
+  );
 
   fields: FormlyFieldConfig[] = [
     {
@@ -102,8 +108,10 @@ export class NotebookAddComponent implements OnInit {
     return `Notebook with name '${name}' already exists`;
   }
 
-  createNotebookFn = (data: Notebook) =>
-    this.service
+  createNotebookFn = (data: Notebook) => {
+    if (!this.canCreateNotebook()) return of(null);
+
+    return this.service
       .create(`projects/${this.projectId}/notebooks`, {
         ...data,
         description: typeof data.description === 'object' ? toHTML(data.description) : data.description,
@@ -119,4 +127,5 @@ export class NotebookAddComponent implements OnInit {
           this.router.navigate(['/notebooks', newNotebook.id]);
         }),
       );
+  };
 }

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
@@ -2,7 +2,7 @@ import { FormDialogComponent } from '@core/components/common/form-dialog/form-di
 import { ApiService } from '@core/services/api.service';
 import { Notebook } from '@core/types/entities/notebook.i';
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
@@ -13,8 +13,7 @@ import { catchError, map, of, switchMap, tap } from 'rxjs';
 import { NotificationType } from '@/core/types/notification.i';
 import { NotificationService } from '@/core/services/notification/notification.service';
 import { Router } from '@angular/router';
-import { PermissionService } from '@core/services/permission/permission.service';
-import { ApplicationPermission } from '@core/types/entities/user.i';
+import { ProjectService } from '@core/services/project/project.service';
 
 @Component({
   standalone: true,
@@ -30,10 +29,7 @@ export class NotebookAddComponent implements OnInit {
   dialogRef = inject(MatDialogRef);
   notificationService = inject(NotificationService);
   router = inject(Router);
-  permissionService = inject(PermissionService);
-  canCreateNotebook = computed(() =>
-    this.permissionService.hasGlobalPermission(ApplicationPermission.CREATE_NOTEBOOKS),
-  );
+  projectService = inject(ProjectService);
 
   fields: FormlyFieldConfig[] = [
     {
@@ -109,7 +105,7 @@ export class NotebookAddComponent implements OnInit {
   }
 
   createNotebookFn = (data: Notebook) => {
-    if (!this.canCreateNotebook()) return of(null);
+    if (!this.projectService.canCreateNotebook()) return of(null);
 
     return this.service
       .create(`projects/${this.projectId}/notebooks`, {

--- a/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.html
@@ -5,5 +5,6 @@
   size="auto"
   containerClass="w-[800px]"
   [toastMessages]="{ uniqueName: uniqueNameToastMessage() }"
+  [submitEnabled]="canEditNotebook()"
   (formSubmit)="editNotebook($event)"
 ></eln-form-dialog>

--- a/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-edit/notebook-edit.component.ts
@@ -3,7 +3,7 @@ import { ApiService } from '@core/services/api.service';
 import { Notebook } from '@core/types/entities/notebook.i';
 import { NotebookDialogData } from '@/core/types/entities/notebook-dialog-data.i';
 import { CommonModule } from '@angular/common';
-import { Component, Inject, inject, signal } from '@angular/core';
+import { Component, computed, Inject, inject, signal } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
@@ -14,6 +14,9 @@ import { of } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { NotificationType } from '@/core/types/notification.i';
 import { NotificationService } from '@/core/services/notification/notification.service';
+import { PermissionService } from '@core/services/permission/permission.service';
+import { ApplicationPermission } from '@core/types/entities/user.i';
+import { NotebookDetail } from '@core/types/entities/notebook-detail.i';
 
 @Component({
   standalone: true,
@@ -26,7 +29,12 @@ export class NotebookEditComponent {
   dialogRef = inject(MatDialogRef);
   notebook: Partial<Notebook> = {};
   notificationService = inject(NotificationService);
+  permissionService = inject(PermissionService);
   uniqueNameToastMessage = signal('');
+  notebookEntity: NotebookDetail | null = null;
+  canEditNotebook = computed(() =>
+    this.permissionService.hasEntityPermission(ApplicationPermission.EDIT_NOTEBOOKS, this.notebookEntity),
+  );
 
   fields: FormlyFieldConfig[] = [
     {
@@ -102,6 +110,7 @@ export class NotebookEditComponent {
     @Inject(MAT_DIALOG_DATA) private data: NotebookDialogData,
   ) {
     if (data?.notebook) {
+      this.notebookEntity = data.notebook;
       this.notebook = {
         name: data.notebook.name,
         description: data.notebook.description,
@@ -111,6 +120,8 @@ export class NotebookEditComponent {
   }
 
   editNotebook(data: Notebook) {
+    if (!this.canEditNotebook()) return;
+
     this.service
       .update(`notebooks/${this.notebookId}`, {
         ...data,

--- a/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.html
@@ -14,7 +14,12 @@
       <div class="px-3">
         <div class="flex items-center justify-between pb-3 border-b border-b-neutral-200">
           <h2 class="font-semibold text-base">About Notebook</h2>
-          <eln-button variant="blue-outline" classList="text-primary-400" (click)="openEditDialog()">
+          <eln-button
+            variant="blue-outline"
+            classList="text-primary-400"
+            (click)="openEditDialog()"
+            [disabled]="!canEditNotebook()"
+          >
             <em class="indicon-edit"></em>
             Edit
           </eln-button>
@@ -34,11 +39,20 @@
           <eln-attachments
             [attachments]="notebook().attachments"
             [baseURL]="`/api/eln/notebooks/${this.notebook().id}`"
+            [requiredPermission]="applicationPermission.EDIT_NOTEBOOKS"
+            [downloadPermission]="applicationPermission.VIEW_NOTEBOOKS"
+            [entity]="notebook()"
             (attachmentsChanged)="onAttachmentsChanged($event)"
           />
         </div>
       </div>
     </eln-card>
-    <eln-team [team]="notebook().acl" [entityId]="notebook().id" [config]="notebookTeamConfig" />
+    <eln-team
+      [team]="notebook().acl"
+      [entityId]="notebook().id"
+      [config]="notebookTeamConfig"
+      [requiredPermission]="applicationPermission.MANAGE_NOTEBOOK_ACCESS"
+      [entity]="notebook()"
+    />
   </div>
 }

--- a/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-info/notebook-info.component.ts
@@ -9,6 +9,9 @@ import { NotebookEditComponent } from '@pages/notebook/notebook-edit/notebook-ed
 import { MatDialog } from '@angular/material/dialog';
 import { AttachmentsComponent } from '@core/components/common/attachments/attachments.component';
 import { Attachment } from '@core/types/entities/attachment.i';
+import { PermissionService } from '@core/services/permission/permission.service';
+import { ApplicationPermission } from '@core/types/entities/user.i';
+import { computed } from '@angular/core';
 
 @Component({
   selector: 'eln-notebook-info',
@@ -19,13 +22,18 @@ import { Attachment } from '@core/types/entities/attachment.i';
 export class NotebookInfoComponent {
   private store = inject(NotebookService);
   private dialog = inject(MatDialog);
+  private permissionService = inject(PermissionService);
 
   notebook = this.store.notebook;
   isLoading = this.store.isLoading;
   hasError = this.store.hasError;
+  applicationPermission = ApplicationPermission;
+  canEditNotebook = computed(() => {
+    return this.permissionService.hasEntityPermission(ApplicationPermission.EDIT_NOTEBOOKS, this.notebook());
+  });
 
   openEditDialog() {
-    if (!this.notebook()) return;
+    if (!this.notebook() || !this.canEditNotebook()) return;
 
     const dialogRef = this.dialog.open(NotebookEditComponent, {
       data: { notebook: this.notebook() },

--- a/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.html
@@ -36,7 +36,7 @@
   variant="blue"
   classList="flex items-center gap-2"
   (click)="openModal()"
-  [disabled]="!canCreateNotebook()"
+  [disabled]="!projectService.canCreateNotebook()"
 >
   <em class="text-xl indicon-plus"></em>
   <span class="whitespace-nowrap">Add Notebook</span>

--- a/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.html
@@ -31,7 +31,13 @@
   />
 </div>
 
-<eln-button *projectOverviewWidget="'button'" variant="blue" classList="flex items-center gap-2" (click)="openModal()">
+<eln-button
+  *projectOverviewWidget="'button'"
+  variant="blue"
+  classList="flex items-center gap-2"
+  (click)="openModal()"
+  [disabled]="!canCreateNotebook()"
+>
   <em class="text-xl indicon-plus"></em>
   <span class="whitespace-nowrap">Add Notebook</span>
 </eln-button>

--- a/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.ts
@@ -1,6 +1,6 @@
 import { animate, style, transition, trigger } from '@angular/animations';
 import { CommonModule } from '@angular/common';
-import { Component, inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, computed, inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
@@ -15,6 +15,8 @@ import { NotebookAddComponent } from '@pages/notebook/notebook-add/notebook-add.
 import { NotebookItemComponent } from '@pages/notebook/notebook-item/notebook-item.component';
 import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
 import { take } from 'rxjs';
+import { PermissionService } from '@core/services/permission/permission.service';
+import { ApplicationPermission } from '@core/types/entities/user.i';
 
 @Component({
   selector: 'eln-notebook-list',
@@ -42,6 +44,10 @@ import { take } from 'rxjs';
 })
 export class NotebookListComponent extends InfiniteScrollBase<Notebook> implements OnInit, OnChanges {
   dialog = inject(MatDialog);
+  permissionService = inject(PermissionService);
+  canCreateNotebook = computed(() =>
+    this.permissionService.hasGlobalPermission(ApplicationPermission.CREATE_NOTEBOOKS),
+  );
   selectedView: 'grid' | 'list' = 'grid';
   @Input() projectId!: string;
   headerSortOptions: DropdownMenuItem[] = [];
@@ -82,6 +88,8 @@ export class NotebookListComponent extends InfiniteScrollBase<Notebook> implemen
   }
 
   async openModal() {
+    if (!this.canCreateNotebook()) return;
+
     const ref = this.dialog.open(NotebookAddComponent);
     ref.componentInstance.projectId = this.projectId;
     ref

--- a/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-list/notebook-list.component.ts
@@ -1,6 +1,6 @@
 import { animate, style, transition, trigger } from '@angular/animations';
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
@@ -11,12 +11,11 @@ import { InfiniteLoaderComponent } from '@core/components/util/infinite-loader/i
 import { InfiniteScrollBase } from '@core/components/util/infinite-scroll.base';
 import { ClassPickerPipe } from '@core/pipes/classPicker.pipe';
 import { Notebook } from '@core/types/entities/notebook.i';
+import { ProjectService } from '@core/services/project/project.service';
 import { NotebookAddComponent } from '@pages/notebook/notebook-add/notebook-add.component';
 import { NotebookItemComponent } from '@pages/notebook/notebook-item/notebook-item.component';
 import { ProjectOverviewWidgetDirective } from '@pages/project/projects-overview-widget/directives/project-overview-widget.directive';
 import { take } from 'rxjs';
-import { PermissionService } from '@core/services/permission/permission.service';
-import { ApplicationPermission } from '@core/types/entities/user.i';
 
 @Component({
   selector: 'eln-notebook-list',
@@ -44,10 +43,7 @@ import { ApplicationPermission } from '@core/types/entities/user.i';
 })
 export class NotebookListComponent extends InfiniteScrollBase<Notebook> implements OnInit, OnChanges {
   dialog = inject(MatDialog);
-  permissionService = inject(PermissionService);
-  canCreateNotebook = computed(() =>
-    this.permissionService.hasGlobalPermission(ApplicationPermission.CREATE_NOTEBOOKS),
-  );
+  projectService = inject(ProjectService);
   selectedView: 'grid' | 'list' = 'grid';
   @Input() projectId!: string;
   headerSortOptions: DropdownMenuItem[] = [];
@@ -88,7 +84,7 @@ export class NotebookListComponent extends InfiniteScrollBase<Notebook> implemen
   }
 
   async openModal() {
-    if (!this.canCreateNotebook()) return;
+    if (!this.projectService.canCreateNotebook()) return;
 
     const ref = this.dialog.open(NotebookAddComponent);
     ref.componentInstance.projectId = this.projectId;

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
@@ -75,6 +75,7 @@
   classList="flex items-center gap-2"
   *projectOverviewWidget="'button'"
   (click)="openModal(projectInfoModalEnum.NOTEBOOK)"
+  [disabled]="!canCreateNotebook()"
 >
   <em class="text-xl indicon-plus"></em>
   <span class="whitespace-nowrap">Add Notebook</span>

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.html
@@ -75,7 +75,7 @@
   classList="flex items-center gap-2"
   *projectOverviewWidget="'button'"
   (click)="openModal(projectInfoModalEnum.NOTEBOOK)"
-  [disabled]="!canCreateNotebook()"
+  [disabled]="!projectService.canCreateNotebook()"
 >
   <em class="text-xl indicon-plus"></em>
   <span class="whitespace-nowrap">Add Notebook</span>

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -53,9 +53,6 @@ export class ProjectInfoComponent {
     const project = this.project();
     return this.permissionService.hasEntityPermission(ApplicationPermission.EDIT_PROJECTS, project);
   });
-  canCreateNotebook = computed(() =>
-    this.permissionService.hasGlobalPermission(ApplicationPermission.CREATE_NOTEBOOKS),
-  );
 
   projectTeamConfig: TeamComponentConfig = {
     buildAccessEndpoint: (id: string) => `projects/${id}/access`,
@@ -81,7 +78,7 @@ export class ProjectInfoComponent {
     }
 
     if (mode === projectInfoModalEnum.NOTEBOOK) {
-      if (!this.canCreateNotebook()) return;
+      if (!this.projectService.canCreateNotebook()) return;
 
       ref = this.dialog.open(NotebookAddComponent);
       (ref.componentInstance as NotebookAddComponent).projectId = this.projectId;

--- a/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-info/project-info.component.ts
@@ -51,8 +51,11 @@ export class ProjectInfoComponent {
   hasError = this.projectService.hasError;
   canEditProject = computed(() => {
     const project = this.project();
-    return project ? this.permissionService.hasPermission(ApplicationPermission.EDIT_PROJECTS, project) : false;
+    return this.permissionService.hasEntityPermission(ApplicationPermission.EDIT_PROJECTS, project);
   });
+  canCreateNotebook = computed(() =>
+    this.permissionService.hasGlobalPermission(ApplicationPermission.CREATE_NOTEBOOKS),
+  );
 
   projectTeamConfig: TeamComponentConfig = {
     buildAccessEndpoint: (id: string) => `projects/${id}/access`,
@@ -78,6 +81,8 @@ export class ProjectInfoComponent {
     }
 
     if (mode === projectInfoModalEnum.NOTEBOOK) {
+      if (!this.canCreateNotebook()) return;
+
       ref = this.dialog.open(NotebookAddComponent);
       (ref.componentInstance as NotebookAddComponent).projectId = this.projectId;
     }

--- a/indigo-frontend/src/app/pages/project/project-list/project-list.component.ts
+++ b/indigo-frontend/src/app/pages/project/project-list/project-list.component.ts
@@ -49,7 +49,7 @@ export class ProjectListComponent extends InfiniteScrollBase<Project> implements
   breadcrumbsState = inject(BreadcrumbsStateService);
   permissionService = inject(PermissionService);
   applicationPermission = ApplicationPermission;
-  canCreateProject = computed(() => this.permissionService.hasPermission(ApplicationPermission.CREATE_PROJECTS));
+  canCreateProject = computed(() => this.permissionService.hasGlobalPermission(ApplicationPermission.CREATE_PROJECTS));
 
   selectedView: 'grid' | 'list' = 'grid';
   private refreshSub!: Subscription;

--- a/indigo-frontend/src/core/components/common/attachment/attachment.component.html
+++ b/indigo-frontend/src/core/components/common/attachment/attachment.component.html
@@ -18,11 +18,11 @@
         <mat-icon>more_horiz</mat-icon>
       </button>
       <mat-menu #menu="matMenu">
-        <button mat-menu-item [disabled]="!canDownload()" (click)="canDownload() && downloadAttachment()">
+        <button mat-menu-item [disabled]="!canDownload()" (click)="downloadAttachment()">
           <mat-icon>download</mat-icon>
           <span>Download</span>
         </button>
-        <button mat-menu-item [disabled]="!canDelete()" (click)="canDelete() && deleteAttachment()">
+        <button mat-menu-item [disabled]="!canDelete()" (click)="deleteAttachment()">
           <mat-icon>delete</mat-icon>
           <span>Delete</span>
         </button>

--- a/indigo-frontend/src/core/components/common/attachment/attachment.component.html
+++ b/indigo-frontend/src/core/components/common/attachment/attachment.component.html
@@ -18,7 +18,7 @@
         <mat-icon>more_horiz</mat-icon>
       </button>
       <mat-menu #menu="matMenu">
-        <button mat-menu-item (click)="downloadAttachment()">
+        <button mat-menu-item [disabled]="!canDownload()" (click)="canDownload() && downloadAttachment()">
           <mat-icon>download</mat-icon>
           <span>Download</span>
         </button>

--- a/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
+++ b/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
@@ -18,6 +18,7 @@ export class AttachmentComponent {
   attachment = input.required<Attachment>();
   baseURL = input.required<string>();
   canDelete = input<boolean>(true);
+  canDownload = input<boolean>(true);
 
   attachmentDeleted = output<string>();
 
@@ -45,12 +46,16 @@ export class AttachmentComponent {
   }
 
   downloadAttachment() {
+    if (!this.canDownload()) return;
+
     this.downloadService
       .download('get', `${this.baseURL()}/attachments/${this.attachment().id}`, 'attachment')
       .subscribe();
   }
 
   deleteAttachment() {
+    if (!this.canDelete()) return;
+
     this.service
       .request<void>('delete', `${this.baseURL()}/attachments/${this.attachment().id}`)
       .subscribe(() => this.attachmentDeleted.emit(this.attachment().id));

--- a/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
+++ b/indigo-frontend/src/core/components/common/attachment/attachment.component.ts
@@ -46,16 +46,12 @@ export class AttachmentComponent {
   }
 
   downloadAttachment() {
-    if (!this.canDownload()) return;
-
     this.downloadService
       .download('get', `${this.baseURL()}/attachments/${this.attachment().id}`, 'attachment')
       .subscribe();
   }
 
   deleteAttachment() {
-    if (!this.canDelete()) return;
-
     this.service
       .request<void>('delete', `${this.baseURL()}/attachments/${this.attachment().id}`)
       .subscribe(() => this.attachmentDeleted.emit(this.attachment().id));

--- a/indigo-frontend/src/core/components/common/attachments/attachments.component.html
+++ b/indigo-frontend/src/core/components/common/attachments/attachments.component.html
@@ -7,6 +7,7 @@
           [attachment]="file"
           [baseURL]="baseURL()"
           [canDelete]="canEdit()"
+          [canDownload]="canDownload()"
           (attachmentDeleted)="onAttachmentDeleted($event)"
         />
       }

--- a/indigo-frontend/src/core/components/common/attachments/attachments.component.ts
+++ b/indigo-frontend/src/core/components/common/attachments/attachments.component.ts
@@ -21,6 +21,7 @@ export class AttachmentsComponent {
   attachments = input.required<Attachment[]>();
   baseURL = input.required<string>();
   requiredPermission = input<ApplicationPermission | null>(null);
+  downloadPermission = input<ApplicationPermission | null>(null);
   entity = input<PermissionedEntity | null>(null);
 
   attachmentsChanged = output<Attachment[]>();
@@ -36,13 +37,16 @@ export class AttachmentsComponent {
   // their current behavior.
   canEdit = computed(() => {
     const permission = this.requiredPermission();
-    return permission == null || this.permissionService.hasPermission(permission, this.entity());
+    return permission == null || this.permissionService.hasEntityPermission(permission, this.entity());
+  });
+
+  canDownload = computed(() => {
+    const permission = this.downloadPermission();
+    return permission == null || this.permissionService.hasEntityPermission(permission, this.entity());
   });
 
   onUpload(newFiles: File[]): void {
-    if (!newFiles.length) {
-      return;
-    }
+    if (!this.canEdit() || !newFiles.length) return;
     this.isUploadingAttachment = true;
 
     const formDatas = newFiles.map((file) => {

--- a/indigo-frontend/src/core/components/common/team/team.component.ts
+++ b/indigo-frontend/src/core/components/common/team/team.component.ts
@@ -76,7 +76,7 @@ export class TeamComponent implements OnInit {
 
   canManage = computed(() => {
     const permission = this.requiredPermission();
-    return permission == null || this.permissionService.hasPermission(permission, this.entity());
+    return permission == null || this.permissionService.hasEntityPermission(permission, this.entity());
   });
 
   userSuggestions: UserRefWithState[] = [];
@@ -121,6 +121,8 @@ export class TeamComponent implements OnInit {
   }
 
   addSelectedUsers(): void {
+    if (!this.canManage()) return;
+
     const endpoint = this.endpoint();
     if (!endpoint) {
       console.error('Cannot add users: missing entity id');
@@ -148,6 +150,8 @@ export class TeamComponent implements OnInit {
   }
 
   updateAclLevel(member: ACLEntry, rawLevel: string): void {
+    if (!this.canManage()) return;
+
     const newLevel = AclLevel[rawLevel as keyof typeof AclLevel];
     if (!newLevel) {
       console.error('Invalid ACL level:', rawLevel);

--- a/indigo-frontend/src/core/services/permission/permission.service.ts
+++ b/indigo-frontend/src/core/services/permission/permission.service.ts
@@ -18,8 +18,11 @@ export class PermissionService {
     this.currentUserPermissions = toSignal(this.identityService.user$.pipe(map((user) => user.permissions)));
   }
 
-  hasPermission(permission: ApplicationPermission, entity?: PermissionedEntity | null): boolean {
-    const permissions = entity ? entity.currentPermissions : this.currentUserPermissions();
-    return !!permissions?.includes(permission);
+  hasGlobalPermission(permission: ApplicationPermission): boolean {
+    return !!this.currentUserPermissions()?.includes(permission);
+  }
+
+  hasEntityPermission(permission: ApplicationPermission, entity: PermissionedEntity | null | undefined): boolean {
+    return !!entity?.currentPermissions?.includes(permission);
   }
 }

--- a/indigo-frontend/src/core/services/project/project.service.ts
+++ b/indigo-frontend/src/core/services/project/project.service.ts
@@ -1,19 +1,27 @@
-import { Injectable, signal } from '@angular/core';
+import { computed, Injectable, signal } from '@angular/core';
 import { ApiService } from '@/core/services/api.service';
 import { catchError, finalize, tap, throwError } from 'rxjs';
+import { PermissionService } from '@core/services/permission/permission.service';
 import { Project } from '@core/types/entities/project.i';
+import { ApplicationPermission } from '@core/types/entities/user.i';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ProjectService {
-  constructor(private api: ApiService<unknown>) {}
+  constructor(
+    private api: ApiService<unknown>,
+    private permissionService: PermissionService,
+  ) {}
 
   // Signals to hold the current project state
   readonly project = signal<Project | null>(null);
   readonly isLoading = signal<boolean>(false);
   readonly hasError = signal<boolean>(false);
   private readonly currentId = signal<string | null>(null);
+  readonly canCreateNotebook = computed(() =>
+    this.permissionService.hasEntityPermission(ApplicationPermission.CREATE_NOTEBOOKS, this.project()),
+  );
 
   load(id: string) {
     this.currentId.set(id);

--- a/indigo-frontend/src/core/types/entities/notebook-detail.i.ts
+++ b/indigo-frontend/src/core/types/entities/notebook-detail.i.ts
@@ -2,8 +2,9 @@ import { UUID } from '@core/types/entities/experiments/experiment-shared.i';
 import { ACLEntry } from './acl.i';
 import { Attachment } from './attachment.i';
 import { BaseEntity } from './base-entity.i';
+import { PermissionedEntity } from './permission.i';
 
-export interface NotebookDetail extends BaseEntity {
+export interface NotebookDetail extends BaseEntity, PermissionedEntity {
   name: string;
   description: string;
   experimentCount?: Record<string, number>;

--- a/indigo-frontend/src/core/types/entities/notebook.i.ts
+++ b/indigo-frontend/src/core/types/entities/notebook.i.ts
@@ -1,8 +1,9 @@
 import { BaseEntity } from './base-entity.i';
 import { ExperimentCountByStatus } from './project.i';
 import { ACLEntry } from '@core/types/entities/acl.i';
+import { PermissionedEntity } from './permission.i';
 
-export interface Notebook extends BaseEntity {
+export interface Notebook extends BaseEntity, PermissionedEntity {
   name: string;
   description: string;
   projectId: string;


### PR DESCRIPTION
- Added explicit handling for global and entity-scoped permissions.
- Applied notebook creation permissions to all notebook creation entry points.
- Restricted notebook editing actions based on entity-level permissions.
- Added permission checks for notebook attachment upload, download, and deletion.
- Restricted notebook team management actions based on access permissions.
- Kept unauthorized actions visible but disabled, with defensive checks to prevent unauthorized requests.

<img width="671" height="412" alt="image" src="https://github.com/user-attachments/assets/ba3a882c-79c3-44a6-9778-83f1b0fe502d" />
