### PR TITLE
Small UI fixes

### DIFF
--- a/indigo-frontend/src/app/app.routes.ts
+++ b/indigo-frontend/src/app/app.routes.ts
@@ -87,13 +87,14 @@ export const routes: Routes = [
             (c) => c.ExperimentLayoutComponent,
           ),
       },
-      {
-        path: 'templates',
-        loadComponent: () =>
-          import('@pages/template/template-layout/template-layout.component').then((c) => c.TemplateLayoutComponent),
-        canActivate: [roleGuard],
-        data: { requiredPermission: ApplicationPermission.MANAGE_TEMPLATES },
-      },
+      // TODO templates are hidden until editing is implemented
+      // {
+      //   path: 'templates',
+      //   loadComponent: () =>
+      //     import('@pages/template/template-layout/template-layout.component').then((c) => c.TemplateLayoutComponent),
+      //   canActivate: [roleGuard],
+      //   data: { requiredPermission: ApplicationPermission.MANAGE_TEMPLATES },
+      // },
       {
         path: 'signatures',
         loadComponent: () =>

--- a/indigo-frontend/src/app/pages/experiment/experiment-actions/sign-dialog/sign-dialog.component.html
+++ b/indigo-frontend/src/app/pages/experiment/experiment-actions/sign-dialog/sign-dialog.component.html
@@ -2,14 +2,8 @@
   title="Select Signature Template"
   submitButtonText="Sign"
   [fields]="fields"
-  [submitEnabled]="!loading()"
+  [contentLoading]="loading()"
+  [contentError]="loadError()"
   (formSubmit)="onSubmit($event)"
 >
-  @if (loading()) {
-    <ng-template #modalContent>
-      <div class="flex justify-center items-center py-8">
-        <mat-spinner diameter="40" />
-      </div>
-    </ng-template>
-  }
 </eln-form-dialog>

--- a/indigo-frontend/src/app/pages/experiment/experiment-actions/sign-dialog/sign-dialog.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/experiment-actions/sign-dialog/sign-dialog.component.ts
@@ -4,9 +4,8 @@ import { FormDialogComponent } from '@core/components/common/form-dialog/form-di
 import { ApiService } from '@core/services/api.service';
 import { MatDialogRef } from '@angular/material/dialog';
 import { FormlyFieldConfig } from '@ngx-formly/core';
-import { map, shareReplay, tap } from 'rxjs/operators';
+import { catchError, map, of, shareReplay, tap } from 'rxjs';
 import { UUID } from '@core/types/entities/experiments/experiment-shared.i';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 interface SignatureTemplateRef {
   id: UUID;
@@ -16,7 +15,7 @@ interface SignatureTemplateRef {
 @Component({
   selector: 'eln-sign-dialog',
   standalone: true,
-  imports: [CommonModule, FormDialogComponent, MatProgressSpinnerModule],
+  imports: [CommonModule, FormDialogComponent],
   templateUrl: './sign-dialog.component.html',
 })
 export class SignDialogComponent implements OnInit {
@@ -24,11 +23,17 @@ export class SignDialogComponent implements OnInit {
   private dialogRef = inject(MatDialogRef<SignDialogComponent>);
 
   loading = signal(true);
+  loadError = signal<string | null>(null);
 
   options$ = this.api.request<SignatureTemplateRef[]>('get', 'signatureTemplates').pipe(
     map((templates) => templates.map((t) => ({ value: t.id, label: t.name }))),
     tap(() => this.loading.set(false)),
-    shareReplay(1), // don't repeat HTTP call for every subscriber
+    catchError(() => {
+      this.loading.set(false);
+      this.loadError.set('Failed to load signature templates');
+      return of([]);
+    }),
+    shareReplay(1),
   );
 
   ngOnInit() {

--- a/indigo-frontend/src/app/pages/experiment/experiment-add/experiment-add.component.html
+++ b/indigo-frontend/src/app/pages/experiment/experiment-add/experiment-add.component.html
@@ -1,26 +1,10 @@
-<ng-container *ngIf="ready; else loadingTpl">
-  <div class="relative w-full">
-    <eln-form-dialog
-      [title]="'Add Experiment'"
-      [fields]="fields"
-      size="auto"
-      containerClass="w-[800px]"
-      [submitEnabled]="!submitting"
-      [hideCancelButton]="submitting"
-      (formSubmit)="createExperiment($event)"
-    >
-    </eln-form-dialog>
-
-    <div *ngIf="submitting" class="absolute inset-0 bg-white/60 flex flex-col items-center justify-center z-50">
-      <mat-spinner diameter="40"></mat-spinner>
-      <div class="mt-2 text-sm text-gray-600">Creating experiment…</div>
-    </div>
-  </div>
-</ng-container>
-
-<ng-template #loadingTpl>
-  <div class="flex flex-col items-center justify-center h-36 gap-3">
-    <mat-spinner diameter="36"></mat-spinner>
-    <div class="text-sm text-gray-500">Loading templates…</div>
-  </div>
-</ng-template>
+<eln-form-dialog
+  [title]="'Add Experiment'"
+  [fields]="fields"
+  size="auto"
+  containerClass="w-[800px]"
+  [contentLoading]="contentLoading"
+  [contentError]="contentError"
+  [submitFn]="createExperimentFn"
+>
+</eln-form-dialog>

--- a/indigo-frontend/src/app/pages/experiment/experiment-add/experiment-add.component.ts
+++ b/indigo-frontend/src/app/pages/experiment/experiment-add/experiment-add.component.ts
@@ -6,13 +6,12 @@ import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Router } from '@angular/router';
 import { NotificationService } from '@core/services/notification/notification.service';
 import { ExperimentDetail } from '@core/types/entities/experiments/experiment-detail.i';
 import { NotificationType } from '@core/types/notification.i';
 import { FormlyFieldConfig } from '@ngx-formly/core';
-import { finalize, map } from 'rxjs/operators';
+import { finalize, map, tap } from 'rxjs/operators';
 
 interface ExperimentForm {
   templateId: string;
@@ -21,14 +20,7 @@ interface ExperimentForm {
 @Component({
   standalone: true,
   selector: 'app-experiment-add',
-  imports: [
-    CommonModule,
-    FormsModule,
-    ReactiveFormsModule,
-    MatInputModule,
-    FormDialogComponent,
-    MatProgressSpinnerModule,
-  ],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, MatInputModule, FormDialogComponent],
   templateUrl: './experiment-add.component.html',
 })
 export class ExperimentAddComponent implements OnInit {
@@ -38,9 +30,8 @@ export class ExperimentAddComponent implements OnInit {
   private notification = inject(NotificationService);
 
   fields: FormlyFieldConfig[] = [];
-  templatesLoading = false;
-  submitting = false;
-  ready = false;
+  contentLoading = true;
+  contentError: string | null = null;
   notebookId: string;
 
   ngOnInit(): void {
@@ -48,26 +39,18 @@ export class ExperimentAddComponent implements OnInit {
     this.loadTemplates();
   }
 
-  createExperiment(formData: ExperimentForm): void {
-    this.submitting = true;
-
+  createExperimentFn = (formData: ExperimentForm) =>
     this.api
       .request<ExperimentDetail>('post', `/notebooks/${this.notebookId}/experiments`, {
         templateID: formData.templateId,
       })
       .pipe(
-        finalize(() => {
-          this.submitting = false;
-        }),
-      )
-      .subscribe({
-        next: (newExperiment: ExperimentDetail) => {
+        tap((newExperiment: ExperimentDetail) => {
           this.showNotification('Experiment created', NotificationType.Success);
           this.dialogRef.close('refresh');
           this.router.navigate(['/experiments', newExperiment.id]);
-        },
-      });
-  }
+        }),
+      );
 
   private initForm(): void {
     this.fields = [
@@ -86,8 +69,6 @@ export class ExperimentAddComponent implements OnInit {
   }
 
   private loadTemplates(): void {
-    this.templatesLoading = true;
-
     this.api
       .request<RootTemplate>('get', 'templates')
       .pipe(
@@ -97,14 +78,14 @@ export class ExperimentAddComponent implements OnInit {
             label: item.name,
           })),
         ),
-        finalize(() => {
-          this.templatesLoading = false;
-          this.ready = true;
-        }),
+        finalize(() => (this.contentLoading = false)),
       )
       .subscribe({
         next: (options) => {
           this.fields[0].props!.options = options;
+        },
+        error: () => {
+          this.contentError = 'Failed to load templates';
         },
       });
   }

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.html
@@ -4,16 +4,9 @@
   [model]="model"
   size="auto"
   containerClass="w-[800px]"
-  (formSubmit)="createNotebook($event)"
+  [contentLoading]="loading"
+  [contentError]="loadError"
+  [submitFn]="createNotebookFn"
   [toastMessages]="{ uniqueName: uniqueNameToastMessage }"
   submitButtonText="Save"
-  [hideSubmitButton]="loading"
->
-  @if (loading) {
-    <ng-template #modalContent>
-      <div class="flex items-center justify-center p-8">
-        <mat-spinner diameter="40" />
-      </div>
-    </ng-template>
-  }
-</eln-form-dialog>
+></eln-form-dialog>

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.html
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.html
@@ -1,9 +1,19 @@
 <eln-form-dialog
   [title]="'Add Notebook'"
   [fields]="fields"
+  [model]="model"
   size="auto"
   containerClass="w-[800px]"
   (formSubmit)="createNotebook($event)"
   [toastMessages]="{ uniqueName: uniqueNameToastMessage }"
   submitButtonText="Save"
-></eln-form-dialog>
+  [hideSubmitButton]="loading"
+>
+  @if (loading) {
+    <ng-template #modalContent>
+      <div class="flex items-center justify-center p-8">
+        <mat-spinner diameter="40" />
+      </div>
+    </ng-template>
+  }
+</eln-form-dialog>

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
@@ -6,11 +6,10 @@ import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
-import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
 import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
-import { catchError, map, of, switchMap } from 'rxjs';
+import { catchError, map, of, switchMap, tap } from 'rxjs';
 import { NotificationType } from '@/core/types/notification.i';
 import { NotificationService } from '@/core/services/notification/notification.service';
 import { Router } from '@angular/router';
@@ -18,12 +17,13 @@ import { Router } from '@angular/router';
 @Component({
   standalone: true,
   selector: 'eln-notebook-add',
-  imports: [MatInputModule, FormsModule, ReactiveFormsModule, CommonModule, FormDialogComponent, MatProgressSpinner],
+  imports: [MatInputModule, FormsModule, ReactiveFormsModule, CommonModule, FormDialogComponent],
   templateUrl: './notebook-add.component.html',
 })
 export class NotebookAddComponent implements OnInit {
   projectId: string;
   loading = true;
+  loadError: string | null = null;
   model: any = {};
   dialogRef = inject(MatDialogRef);
   notificationService = inject(NotificationService);
@@ -85,9 +85,15 @@ export class NotebookAddComponent implements OnInit {
   constructor(protected service: ApiService<Notebook>) {}
 
   ngOnInit() {
-    this.service.request<string>('get', 'notebooks/next-number').subscribe((name) => {
-      this.model = { name };
-      this.loading = false;
+    this.service.request<string>('get', 'notebooks/next-number').subscribe({
+      next: (name) => {
+        this.model = { name };
+        this.loading = false;
+      },
+      error: () => {
+        this.loadError = 'Failed to load next notebook number';
+        this.loading = false;
+      },
     });
   }
 
@@ -95,20 +101,22 @@ export class NotebookAddComponent implements OnInit {
     const name = this.fields[0]?.formControl?.value ?? '';
     return `Notebook with name '${name}' already exists`;
   }
-  createNotebook(data: Notebook) {
+
+  createNotebookFn = (data: Notebook) =>
     this.service
       .create(`projects/${this.projectId}/notebooks`, {
         ...data,
         description: typeof data.description === 'object' ? toHTML(data.description) : data.description,
       })
-      .subscribe((newNotebook: Notebook) => {
-        this.notificationService.notify({
-          message: 'Notebook successfully created.',
-          type: NotificationType.Success,
-          isInline: false,
-        });
-        this.dialogRef.close('refresh');
-        this.router.navigate(['/projects', this.projectId, 'notebooks', newNotebook.id]);
-      });
-  }
+      .pipe(
+        tap((newNotebook: Notebook) => {
+          this.notificationService.notify({
+            message: 'Notebook successfully created.',
+            type: NotificationType.Success,
+            isInline: false,
+          });
+          this.dialogRef.close('refresh');
+          this.router.navigate(['/projects', this.projectId, 'notebooks', newNotebook.id]);
+        }),
+      );
 }

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
@@ -116,7 +116,7 @@ export class NotebookAddComponent implements OnInit {
             isInline: false,
           });
           this.dialogRef.close('refresh');
-          this.router.navigate(['/projects', this.projectId, 'notebooks', newNotebook.id]);
+          this.router.navigate(['/notebooks', newNotebook.id]);
         }),
       );
 }

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
@@ -2,10 +2,11 @@ import { FormDialogComponent } from '@core/components/common/form-dialog/form-di
 import { ApiService } from '@core/services/api.service';
 import { Notebook } from '@core/types/entities/notebook.i';
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatDialogRef } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { FormlyFieldConfig } from '@ngx-formly/core';
 import { toHTML } from 'ngx-editor';
 import { NOTEBOOK_NAME_LENGTH } from '../notebook.constants';
@@ -17,11 +18,13 @@ import { Router } from '@angular/router';
 @Component({
   standalone: true,
   selector: 'eln-notebook-add',
-  imports: [MatInputModule, FormsModule, ReactiveFormsModule, CommonModule, FormDialogComponent],
+  imports: [MatInputModule, FormsModule, ReactiveFormsModule, CommonModule, FormDialogComponent, MatProgressSpinner],
   templateUrl: './notebook-add.component.html',
 })
-export class NotebookAddComponent {
+export class NotebookAddComponent implements OnInit {
   projectId: string;
+  loading = true;
+  model: any = {};
   dialogRef = inject(MatDialogRef);
   notificationService = inject(NotificationService);
   router = inject(Router);
@@ -80,6 +83,14 @@ export class NotebookAddComponent {
   ];
 
   constructor(protected service: ApiService<Notebook>) {}
+
+  ngOnInit() {
+    this.service.request<string>('get', 'notebooks/next-number').subscribe((name) => {
+      this.model = { name };
+      this.loading = false;
+    });
+  }
+
   get uniqueNameToastMessage(): string {
     const name = this.fields[0]?.formControl?.value ?? '';
     return `Notebook with name '${name}' already exists`;

--- a/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
+++ b/indigo-frontend/src/app/pages/notebook/notebook-add/notebook-add.component.ts
@@ -24,7 +24,7 @@ export class NotebookAddComponent implements OnInit {
   projectId: string;
   loading = true;
   loadError: string | null = null;
-  model: any = {};
+  model: { name?: string } = {};
   dialogRef = inject(MatDialogRef);
   notificationService = inject(NotificationService);
   router = inject(Router);

--- a/indigo-frontend/src/core/components/common/form-dialog/form-dialog.component.html
+++ b/indigo-frontend/src/core/components/common/form-dialog/form-dialog.component.html
@@ -38,6 +38,14 @@
       <div class="modal-content p-4 overflow-y-auto flex-grow">
         <ng-container *ngTemplateOutlet="modalContent"></ng-container>
       </div>
+    } @else if (contentLoading) {
+      <div class="modal-content p-4 overflow-y-auto flex-grow flex items-center justify-center">
+        <mat-spinner diameter="40" />
+      </div>
+    } @else if (contentError) {
+      <div class="modal-content p-4 overflow-y-auto flex-grow flex items-center justify-center">
+        <p class="text-sm text-red-500">{{ contentError }}</p>
+      </div>
     } @else {
       <div class="modal-content p-4 overflow-y-auto flex-grow">
         <formly-form [model]="model" [fields]="fields" [form]="form"></formly-form>
@@ -57,12 +65,12 @@
               cancelButtonText
             }}</eln-button>
           }
-          @if (!hideSubmitButton) {
+          @if (!hideSubmitButton && !contentLoading && !contentError) {
             <eln-button
               [type]="'button'"
               [variant]="'blue'"
-              [disabled]="!submitEnabled"
-              [loading]="submitLoading"
+              [disabled]="!submitEnabled || submitting"
+              [loading]="submitLoading || submitting"
               (click)="submit()"
               >{{ submitButtonText }}</eln-button
             >

--- a/indigo-frontend/src/core/components/common/form-dialog/form-dialog.component.ts
+++ b/indigo-frontend/src/core/components/common/form-dialog/form-dialog.component.ts
@@ -6,8 +6,11 @@ import { CommonModule } from '@angular/common';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { TwsxPipe } from '@/core/pipes/twsx.pipe';
 import { FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
 import { ButtonComponent } from '../button/button.component';
 
 @Component({
@@ -24,12 +27,14 @@ import { ButtonComponent } from '../button/button.component';
     FormlyModule,
     ButtonComponent,
     TwsxPipe,
+    MatProgressSpinner,
   ],
 })
 export class FormDialogComponent {
   dialogRef: MatDialogRef<FormDialogComponent> = inject(MatDialogRef);
   private notificationService = inject(NotificationService);
   form = new FormGroup({});
+  submitting = false;
 
   @Input() model: any = {};
   @Input() title = '';
@@ -44,6 +49,9 @@ export class FormDialogComponent {
   @Input() closeOnBackdropClick = false;
   @Input() containerClass = '';
   @Input() toastMessages: Record<string, string> = {};
+  @Input() contentLoading = false;
+  @Input() contentError: string | null = null;
+  @Input() submitFn?: (data: any) => Observable<any>;
   @Output() formSubmit = new EventEmitter<any>();
   @ContentChild('modalHeader') modalHeader: TemplateRef<unknown> | null = null;
   @ContentChild('modalContent') modalContent: TemplateRef<unknown> | null = null;
@@ -55,7 +63,14 @@ export class FormDialogComponent {
       this.showValidationErrors();
       return;
     }
-    this.formSubmit.emit(this.form.value);
+    if (this.submitFn) {
+      this.submitting = true;
+      this.submitFn(this.form.value)
+        .pipe(finalize(() => (this.submitting = false)))
+        .subscribe({ error: () => {} });
+    } else {
+      this.formSubmit.emit(this.form.value);
+    }
   }
 
   private showValidationErrors(): void {

--- a/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
+++ b/indigo-frontend/src/core/components/layout/partials/sidebar/sidebar.component.ts
@@ -32,12 +32,13 @@ export class SidebarComponent implements OnInit {
       icon: 'indicon-briefcase',
       path: '/',
     },
-    {
-      name: 'Templates',
-      icon: 'indicon-layers',
-      path: '/templates',
-      requiredPermission: ApplicationPermission.MANAGE_TEMPLATES,
-    },
+    // TODO templates are hidden until editing is implemented
+    // {
+    //   name: 'Templates',
+    //   icon: 'indicon-layers',
+    //   path: '/templates',
+    //   requiredPermission: ApplicationPermission.MANAGE_TEMPLATES,
+    // },
     {
       name: 'Dictionaries',
       materialIcon: 'import_contacts',

--- a/indigo-frontend/src/core/enums/acl-levels.enum.ts
+++ b/indigo-frontend/src/core/enums/acl-levels.enum.ts
@@ -17,7 +17,7 @@ export const ACL_LEVEL_LABELS: Record<AclLevel, string> = {
   [AclLevel.ADMIN]: 'Admin',
   [AclLevel.EDIT]: 'Can Edit',
   [AclLevel.VIEW]: 'Can View',
-  [AclLevel.IMPLICIT_VIEW]: 'Implicit View',
+  [AclLevel.IMPLICIT_VIEW]: 'Limited View',
   [AclLevel.NONE]: 'None',
   [AclLevel.AUTHOR]: 'Author',
 };


### PR DESCRIPTION
Few minor fixes.

The biggest one is prefill next available notebook number in Create Notebook Dialog. Mainly to later support autotests to avoid "notebook already exists" errors, but should also simplify manual creation

And a small refactoring of dialog state machine. Now it can optionally be "loading" initially (show spinner and disable submit) and "submitting" (show spinner on submit button). We had this pattern already used in few dialogs, so I moved it to common class

Plus:
- disable template tab (agreed with BAs to disable until we have template editing implemented)
- rename "Implicit View" to "Limited View" (agreed with BAs)
- fix notebook not opened after creation